### PR TITLE
Add MovementReferenceNumber model

### DIFF
--- a/app/models/MovementReferenceNumber.scala
+++ b/app/models/MovementReferenceNumber.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import MovementReferenceNumber._
+import play.api.libs.json.{JsString, Reads, Writes}
+import play.api.mvc.PathBindable
+
+import scala.math.pow
+
+final case class MovementReferenceNumber (
+                                           year: String,
+                                           countryCode: String,
+                                           serial: String
+                                         ) {
+
+  override def toString: String = s"$year$countryCode$serial$checkCharacter"
+
+  val checkCharacter: String = {
+
+    val input = s"$year$countryCode$serial"
+
+    val remainder = input.zipWithIndex.map {
+      case (character, index) =>
+        characterWeights(character) * pow(2, index).toInt
+    }.sum % 11
+
+    (remainder % 10).toString
+  }
+}
+
+object MovementReferenceNumber {
+
+  private val mrnFormat = """^(\d{2})([A-Z]{2})([A-Z0-9]{13})(\d)$""".r
+
+  def apply(input: String): Option[MovementReferenceNumber] = input match {
+    case mrnFormat(year, countryCode, serial, checkCharacter) =>
+
+      val mrn = MovementReferenceNumber(year, countryCode, serial)
+
+      if (mrn.checkCharacter == checkCharacter) {
+        Some(mrn)
+      } else {
+        None
+      }
+
+    case _ =>
+      None
+  }
+
+  implicit lazy val reads: Reads[MovementReferenceNumber] = {
+
+    import play.api.libs.json._
+
+    __.read[String].map(MovementReferenceNumber.apply).flatMap {
+      case Some(mrn) => Reads(_ => JsSuccess(mrn))
+      case None      => Reads(_ => JsError("Invalid Movement Reference Number"))
+    }
+  }
+
+  implicit lazy val writes: Writes[MovementReferenceNumber] = Writes {
+    mrn =>
+      JsString(mrn.toString)
+  }
+
+  implicit def pathBindable: PathBindable[MovementReferenceNumber] = new PathBindable[MovementReferenceNumber] {
+
+    override def bind(key: String, value: String): Either[String, MovementReferenceNumber] =
+      MovementReferenceNumber.apply(value).toRight("Invalid Movement Reference Number")
+
+    override def unbind(key: String, value: MovementReferenceNumber): String =
+      value.toString
+  }
+
+  private val characterWeights = Map(
+    '0' -> 0,
+    '1' -> 1,
+    '2' -> 2,
+    '3' -> 3,
+    '4' -> 4,
+    '5' -> 5,
+    '6' -> 6,
+    '7' -> 7,
+    '8' -> 8,
+    '9' -> 9,
+    'A' -> 10,
+    'B' -> 12,
+    'C' -> 13,
+    'D' -> 14,
+    'E' -> 15,
+    'F' -> 16,
+    'G' -> 17,
+    'H' -> 18,
+    'I' -> 19,
+    'J' -> 20,
+    'K' -> 21,
+    'L' -> 23,
+    'M' -> 24,
+    'N' -> 25,
+    'O' -> 26,
+    'P' -> 27,
+    'Q' -> 28,
+    'R' -> 29,
+    'S' -> 30,
+    'T' -> 31,
+    'U' -> 32,
+    'V' -> 34,
+    'W' -> 35,
+    'X' -> 36,
+    'Y' -> 37,
+    'Z' -> 38
+  )
+}

--- a/test/generators/MessageGenerators.scala
+++ b/test/generators/MessageGenerators.scala
@@ -20,7 +20,7 @@ import java.time.LocalDate
 
 import models.messages._
 import models.messages.request._
-import models.{EnRouteEvent, RejectionError, Trader, TraderWithEori, TraderWithoutEori}
+import models.{EnRouteEvent, MovementReferenceNumber, RejectionError, Trader, TraderWithEori, TraderWithoutEori}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.{Arbitrary, Gen}
 
@@ -71,7 +71,7 @@ trait MessageGenerators extends ModelGenerators {
     Arbitrary {
 
       for {
-        mrn                <- arbitrary[String]
+        mrn                <- arbitrary[MovementReferenceNumber].map(_.toString())
         place              <- arbitrary[String]
         date               <- datesBetween(LocalDate.of(1900, 1, 1), LocalDate.now)
         subPlace           <- arbitrary[Option[String]]
@@ -85,7 +85,7 @@ trait MessageGenerators extends ModelGenerators {
     Arbitrary {
 
       for {
-        mrn                <- arbitrary[String]
+        mrn                <- arbitrary[MovementReferenceNumber].map(_.toString())
         place              <- arbitrary[String]
         date               <- datesBetween(LocalDate.of(1900, 1, 1), LocalDate.now)
         approvedLocation   <- arbitrary[Option[String]]

--- a/test/generators/ModelGenerators.scala
+++ b/test/generators/ModelGenerators.scala
@@ -46,6 +46,15 @@ trait ModelGenerators {
     }
   }
 
+  implicit lazy  val arbitraryMovementReferenceNumber: Arbitrary[MovementReferenceNumber] =
+    Arbitrary {
+      for {
+        year    <- Gen.choose(0, 99).map(y => f"$y%02d")
+        country <- Gen.pick(2, 'A' to 'Z')
+        serial  <- Gen.pick(13, ('A' to 'Z') ++ ('0' to '9'))
+      } yield MovementReferenceNumber(year, country.mkString, serial.mkString)
+    }
+
   implicit lazy val arbitraryProcedureType: Arbitrary[ProcedureType] =
     Arbitrary {
       Gen.oneOf(ProcedureType.Normal, ProcedureType.Simplified)

--- a/test/models/MovementReferenceNumberSpec.scala
+++ b/test/models/MovementReferenceNumberSpec.scala
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import generators.ModelGenerators
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import org.scalatest.{EitherValues, FreeSpec, MustMatchers, OptionValues}
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.libs.json.{JsString, Json}
+import play.api.mvc.PathBindable
+
+class MovementReferenceNumberSpec extends FreeSpec with MustMatchers with ScalaCheckPropertyChecks
+  with ModelGenerators with EitherValues with OptionValues {
+
+  "a Movement Reference Number" - {
+
+    val pathBindable = implicitly[PathBindable[MovementReferenceNumber]]
+
+    "must bind from a url" in {
+
+      val mrn = MovementReferenceNumber("99IT9876AB88901209")
+
+      val result = pathBindable.bind("mrn", "99IT9876AB88901209")
+
+      result.right.value mustEqual mrn.value
+    }
+
+    "must deserialise" in {
+
+      forAll(arbitrary[MovementReferenceNumber]) {
+        mrn =>
+
+          JsString(mrn.toString).as[MovementReferenceNumber] mustEqual mrn
+      }
+    }
+
+    "must serialise" in {
+
+      forAll(arbitrary[MovementReferenceNumber]) {
+        mrn =>
+
+          Json.toJson(mrn) mustEqual JsString(mrn.toString)
+      }
+    }
+
+    "must fail to bind from a string that isn't 18 characters long" in {
+
+      val gen = for {
+        digits <- Gen.choose[Int](1, 30).suchThat(_ != 18)
+        value  <- Gen.pick(digits, ('A' to 'Z') ++ ('0' to '9'))
+      } yield value.mkString
+
+      forAll(gen) {
+        invalidMrn =>
+
+          MovementReferenceNumber(invalidMrn) must not be defined
+      }
+    }
+
+    "must fail to bind from a string that has any characters which aren't upper case or digits" in {
+
+      val gen: Gen[(MovementReferenceNumber, Int, Char)] = for {
+        mrn       <- arbitrary[MovementReferenceNumber]
+        index     <- Gen.choose(0, 17)
+        character <- arbitrary[Char]
+      } yield (mrn, index, character)
+
+      forAll(gen) {
+        case (mrn, index, character) =>
+
+          val validCharacters = "1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+          whenever (!validCharacters.contains(character)) {
+
+            val invalidMrn = mrn.toString.updated(index, character)
+
+            MovementReferenceNumber(invalidMrn) must not be defined
+          }
+      }
+    }
+
+    "must fail to bind from a string that does not have a digit as the first characters" in {
+
+      forAll(arbitrary[MovementReferenceNumber], Gen.alphaUpperChar) {
+        (mrn, upperCaseChar) =>
+
+          val invalidMrn = mrn.toString.updated(0, upperCaseChar)
+
+          MovementReferenceNumber(invalidMrn) must not be defined
+      }
+    }
+
+    "must fail to bind from a string that does not have a digit as the second characters" in {
+
+      forAll(arbitrary[MovementReferenceNumber], Gen.alphaUpperChar) {
+        (mrn, upperCaseChar) =>
+
+          val invalidMrn = mrn.toString.updated(1, upperCaseChar)
+
+          MovementReferenceNumber(invalidMrn) must not be defined
+      }
+    }
+
+    "must fail to bind a string that does not have an upper case character as the third character" in {
+
+      forAll(arbitrary[MovementReferenceNumber], Gen.numChar) {
+        (mrn, digit) =>
+
+          val invalidMrn = mrn.toString.updated(2, digit)
+
+          MovementReferenceNumber(invalidMrn) must not be defined
+      }
+    }
+
+    "must fail to bind a string that does not have an upper case character as the fourth character" in {
+
+      forAll(arbitrary[MovementReferenceNumber], Gen.numChar) {
+        (mrn, digit) =>
+
+          val invalidMrn = mrn.toString.updated(3, digit)
+
+          MovementReferenceNumber(invalidMrn) must not be defined
+      }
+    }
+
+    "must build from a valid MRN" in {
+
+      MovementReferenceNumber("99IT9876AB88901209").value mustEqual MovementReferenceNumber("99", "IT", "9876AB8890120")
+      MovementReferenceNumber("18GB0000601001EB15").value mustEqual MovementReferenceNumber("18", "GB", "0000601001EB1")
+      MovementReferenceNumber("18GB0000601001EBD1").value mustEqual MovementReferenceNumber("18", "GB", "0000601001EBD")
+      MovementReferenceNumber("18IT02110010006A10").value mustEqual MovementReferenceNumber("18", "IT", "02110010006A1")
+      MovementReferenceNumber("18IT021100100069F4").value mustEqual MovementReferenceNumber("18", "IT", "021100100069F")
+      MovementReferenceNumber("18GB0000601001EBB5").value mustEqual MovementReferenceNumber("18", "GB", "0000601001EBB")
+    }
+
+    "must treat .apply and .toString as dual" in {
+
+      forAll(arbitrary[MovementReferenceNumber]) {
+        mrn =>
+
+          MovementReferenceNumber(mrn.toString).value mustEqual mrn
+      }
+    }
+
+    "must fail to bind from inputs with invalid check characters" in {
+
+      val checkDigitPosition = 17
+
+      val gen = for {
+        mrn               <- arbitrary[MovementReferenceNumber].map(_.toString)
+        invalidCheckDigit <- Gen.alphaChar suchThat (_ != mrn(checkDigitPosition))
+      } yield (mrn, invalidCheckDigit)
+
+      forAll(gen) {
+        case (mrn, invalidCheckDigit) =>
+
+          val invalidMrn = mrn.toString.updated(checkDigitPosition, invalidCheckDigit)
+
+          MovementReferenceNumber(invalidMrn) must not be defined
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added in the MovementReferenceNumber model so ArrivalNotifications always generate a valid MRN. Haven't updated the other arbitrary values yet, want to get this in first.