### PR TITLE
Update dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,3 +48,5 @@ lazy val itSettings = Defaults.itSettings ++ Seq(
   ),
   scalafmtTestOnCompile in ThisBuild := true
 )
+
+dependencyOverrides ++= AppDependencies.overrides

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,7 +8,7 @@ object AppDependencies {
   val compile = Seq(
 
     "org.reactivemongo"       %% "play2-reactivemongo"      % "0.18.6-play26",
-    "uk.gov.hmrc"             %% "bootstrap-play-26"        % "1.1.0"
+    "uk.gov.hmrc"             %% "bootstrap-play-26"        % "1.4.0"
   )
 
   val test = Seq(
@@ -20,4 +20,15 @@ object AppDependencies {
     "org.scalacheck"          %% "scalacheck"               % "1.14.1",
     "com.github.tomakehurst"  %  "wiremock-standalone"      % "2.17.0"
   ).map(_ % "test, it")
+
+  val akkaVersion = "2.5.23"
+  val akkaHttpVersion = "10.0.15"
+
+  val overrides = Seq(
+    "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+    "com.typesafe.akka" %% "akka-protobuf" % akkaVersion,
+    "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
+    "com.typesafe.akka" %% "akka-actor" % akkaVersion,
+    "com.typesafe.akka" %% "akka-http-core" % akkaHttpVersion
+  )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 resolvers += Resolver.typesafeRepo("releases")
 
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
@@ -14,7 +14,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.24")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 


### PR DESCRIPTION
We need to pin various akka components back to specific versions
as the version of reactivemongo we use is incompatible with the
versions that would otherwise be brought in by Play 2.6.24.