### PR TITLE
Guice helper trait

### DIFF
--- a/test/base/GuiceBindingHelpers.scala
+++ b/test/base/GuiceBindingHelpers.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package base
+
+import controllers.actions.FakeIdentifierAction
+import controllers.actions.IdentifierAction
+import org.scalatest.TestSuite
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+
+import scala.reflect.ClassTag
+
+trait GuiceBindingHelpers extends GuiceOneAppPerSuite {
+  self: TestSuite =>
+
+  protected def applicationBuilder: GuiceApplicationBuilder =
+    new GuiceApplicationBuilder()
+      .overrides(
+        bind[IdentifierAction].to[FakeIdentifierAction]
+      )
+
+  /*
+  The functions below are an attempt to refactor the massive and complex chaining of
+   */
+
+  protected val startWithApplicationBuilder: Unit => GuiceApplicationBuilder = _ => new GuiceApplicationBuilder()
+
+  protected def withFakeIdentifierAction(applicationBuilder: GuiceApplicationBuilder): GuiceApplicationBuilder =
+    applicationBuilder.overrides(bind[IdentifierAction].to[FakeIdentifierAction])
+
+  protected def withBinding[A: ClassTag](a: A): GuiceApplicationBuilder => GuiceApplicationBuilder =
+    _.overrides(bind[A].toInstance(a))
+
+}

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -19,8 +19,6 @@ package base
 import java.time.LocalDate
 
 import config.AppConfig
-import controllers.actions.FakeIdentifierAction
-import controllers.actions.IdentifierAction
 import models.messages.NormalNotificationMessage
 import models.messages.TraderWithEori
 import org.scalatest.FreeSpec
@@ -28,17 +26,14 @@ import org.scalatest.MustMatchers
 import org.scalatest.OptionValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.inject.Injector
-import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import reactivemongo.api.commands.UpdateWriteResult
 import reactivemongo.api.commands.WriteResult
 import uk.gov.hmrc.http.HeaderCarrier
 
-trait SpecBase extends FreeSpec with GuiceOneAppPerSuite with MustMatchers with MockitoSugar with ScalaFutures with OptionValues {
+trait SpecBase extends FreeSpec with GuiceBindingHelpers with MustMatchers with MockitoSugar with ScalaFutures with OptionValues {
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
 
@@ -47,12 +42,6 @@ trait SpecBase extends FreeSpec with GuiceOneAppPerSuite with MustMatchers with 
   def appConfig: AppConfig = injector.instanceOf[AppConfig]
 
   def fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("", "")
-
-  protected def applicationBuilder: GuiceApplicationBuilder =
-    new GuiceApplicationBuilder()
-      .overrides(
-        bind[IdentifierAction].to[FakeIdentifierAction]
-      )
 
   lazy val normalNotification = NormalNotificationMessage(
     movementReferenceNumber = "movementReferenceNumber",


### PR DESCRIPTION
Move dependency building concerns out to a seperate trait

Splitting the Guice application builder work out into a seperate trait which can later removed from SpecBase as a hard dependency.

This isolation is to allow for easier experimentation with building application with composeable function as opposed to chaning GuiceApplcaitionBuilder values.
