### PR TITLE
Simplify creation of arrival movement

### DIFF
--- a/app/controllers/MovementsController.scala
+++ b/app/controllers/MovementsController.scala
@@ -44,29 +44,31 @@ class MovementsController @Inject()(
 
   def createMovement: Action[NodeSeq] = identify.async(parse.xml) {
     implicit request =>
-      arrivalMovementService.makeArrivalMovement(request.eoriNumber)(request.body) match {
-        case None =>
-          Future.successful(BadRequest("Invalid data: missing either DatOfPreMES9, TimOfPreMES10 or DocNumHEA5"))
+//      arrivalMovementService.makeArrivalMovement(request.eoriNumber)(request.body) match {
+      ////        case None =>
+      ////          Future.successful(BadRequest("Invalid data: missing either DatOfPreMES9, TimOfPreMES10 or DocNumHEA5"))
+      ////
+      ////        case Some(x) =>
+      ////          x.flatMap {
+      ////            case None =>
+      ////              Future.successful(InternalServerError)
+      ////
+      ////            case Some(arrivalMovement) =>
+      ////              databaseService
+      ////                .saveArrivalMovement(arrivalMovement)
+      ////                .map {
+      ////                  case Right(_) =>
+      ////                    Accepted("Message accepted")
+      ////                    // TODO: This needs to be replaced url to arrival movement resource, for which we need an Arrival Movement number
+      ////                      .withHeaders("Location" -> arrivalMovement.internalReferenceId.toString)
+      ////
+      ////                  case _ =>
+      ////                    InternalServerError
+      ////                }
+      ////          }
+      ////      }
 
-        case Some(x) =>
-          x.flatMap {
-            case None =>
-              Future.successful(InternalServerError)
-
-            case Some(arrivalMovement) =>
-              databaseService
-                .saveArrivalMovement(arrivalMovement)
-                .map {
-                  case Right(_) =>
-                    Accepted("Message accepted")
-                    // TODO: This needs to be replaced url to arrival movement resource, for which we need an Arrival Movement number
-                      .withHeaders("Location" -> arrivalMovement.internalReferenceId.toString)
-
-                  case _ =>
-                    InternalServerError
-                }
-          }
-      }
+      ???
   }
 
   def getMovements: Action[AnyContent] = identify.async {

--- a/app/controllers/MovementsController.scala
+++ b/app/controllers/MovementsController.scala
@@ -44,31 +44,28 @@ class MovementsController @Inject()(
 
   def createMovement: Action[NodeSeq] = identify.async(parse.xml) {
     implicit request =>
-//      arrivalMovementService.makeArrivalMovement(request.eoriNumber)(request.body) match {
-      ////        case None =>
-      ////          Future.successful(BadRequest("Invalid data: missing either DatOfPreMES9, TimOfPreMES10 or DocNumHEA5"))
-      ////
-      ////        case Some(x) =>
-      ////          x.flatMap {
-      ////            case None =>
-      ////              Future.successful(InternalServerError)
-      ////
-      ////            case Some(arrivalMovement) =>
-      ////              databaseService
-      ////                .saveArrivalMovement(arrivalMovement)
-      ////                .map {
-      ////                  case Right(_) =>
-      ////                    Accepted("Message accepted")
-      ////                    // TODO: This needs to be replaced url to arrival movement resource, for which we need an Arrival Movement number
-      ////                      .withHeaders("Location" -> arrivalMovement.internalReferenceId.toString)
-      ////
-      ////                  case _ =>
-      ////                    InternalServerError
-      ////                }
-      ////          }
-      ////      }
+      arrivalMovementService.makeArrivalMovement(request.eoriNumber)(request.body) match {
+        case None =>
+          Future.successful(BadRequest("Invalid data: missing either DatOfPreMES9, TimOfPreMES10 or DocNumHEA5"))
 
-      ???
+        case Some(x) =>
+          x.flatMap {
+              arrival =>
+                arrivalMovementRepository.insert(arrival) map {
+                  _ =>
+                    Accepted("Message accepted")
+                    // TODO: This needs to be replaced url to arrival movement resource, for which we need an Arrival Movement number
+                      .withHeaders("Location" -> arrival.arrivalId.index.toString)
+                }
+            }
+            .recover {
+              case _ => {
+                // TODO: Add logging here so that we can be alerted to these issues.
+                InternalServerError
+              }
+            }
+
+      }
   }
 
   def getMovements: Action[AnyContent] = identify.async {

--- a/app/models/Arrival.scala
+++ b/app/models/Arrival.scala
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-package models.request
+package models
+
+import models.request.ArrivalId
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
 
-case class ArrivalId(index: Int)
+case class Arrival(arrivalId: ArrivalId, movementReferenceNumber: String, eoriNumber: String, messages: Seq[TimeStampedMessageXml])
 
-object ArrivalId {
-  implicit val formatsArrivalId: OFormat[ArrivalId] = Json.format[ArrivalId]
+object Arrival {
+
+  implicit val formatsArrival: OFormat[Arrival] = Json.format[Arrival]
+
 }

--- a/app/models/ArrivalMovement.scala
+++ b/app/models/ArrivalMovement.scala
@@ -19,7 +19,7 @@ package models
 import play.api.libs.json.Json
 import play.api.libs.json.OFormat
 
-case class ArrivalMovement(internalReferenceId: Int, movementReferenceNumber: String, eoriNumber: String, messages: Seq[TimeStampedMessage])
+case class ArrivalMovement(internalReferenceId: Int, movementReferenceNumber: String, eoriNumber: String, messages: Seq[TimeStampedMessageJson])
 
 object ArrivalMovement {
   implicit val formats: OFormat[ArrivalMovement] = Json.format[ArrivalMovement]

--- a/app/models/request/ArrivalId.scala
+++ b/app/models/request/ArrivalId.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.request
+import play.api.libs.json.Json
+import play.api.libs.json.OFormat
+
+case class ArrivalId(index: Int)
+
+object ArrivalId {
+  implicit val formats: OFormat[ArrivalId] = Json.format[ArrivalId]
+}

--- a/app/repositories/ArrivalIdRepository.scala
+++ b/app/repositories/ArrivalIdRepository.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories
+
+import com.google.inject.Inject
+import models.request.ArrivalId
+import play.api.libs.json.Json
+import play.api.libs.json.Reads
+import play.modules.reactivemongo.ReactiveMongoApi
+import reactivemongo.play.json.collection.JSONCollection
+import reactivemongo.play.json.ImplicitBSONHandlers.JsObjectDocumentWriter
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits._
+
+class ArrivalIdRepository @Inject()(mongo: ReactiveMongoApi) {
+
+  private val lastIndexKey = "last-index"
+  private val primaryValue = "record_id"
+
+  private val collectionName: String = ArrivalIdRepository.collectionName
+
+  private val indexKeyReads: Reads[Int] = {
+    import play.api.libs.json._
+    (__ \ lastIndexKey).read[Int]
+  }
+
+  private def collection: Future[JSONCollection] =
+    mongo.database.map(_.collection[JSONCollection](collectionName))
+
+  def nextId(): Future[ArrivalId] = {
+
+    val update = Json.obj(
+      "$inc" -> Json.obj(lastIndexKey -> 1)
+    )
+
+    val selector = Json.obj("_id" -> primaryValue)
+
+    collection.flatMap(
+      _.findAndUpdate(selector, update, upsert = true, fetchNewObject = true)
+        .map(
+          x =>
+            x.result(indexKeyReads)
+              .map(increment => ArrivalId(increment))
+              .getOrElse(throw new Exception(s"Unable to generate ArrivalId")))
+    )
+  }
+}
+
+object ArrivalIdRepository {
+
+  val collectionName = "arrival-ids"
+}

--- a/app/repositories/ArrivalMovementRepository.scala
+++ b/app/repositories/ArrivalMovementRepository.scala
@@ -17,6 +17,7 @@
 package repositories
 
 import com.google.inject.Inject
+import models.Arrival
 import models.ArrivalMovement
 import play.api.libs.json.JsObject
 import play.api.libs.json.Json
@@ -53,6 +54,14 @@ class ArrivalMovementRepository @Inject()(cc: ControllerComponents, mongo: React
   private def collection: Future[JSONCollection] =
     mongo.database.map(_.collection[JSONCollection](collectionName))
 
+  def insert(arrival: Arrival): Future[Unit] =
+    collection.flatMap {
+      _.insert(false)
+        .one(Json.toJsObject(arrival))
+        .map(_ => ())
+    }
+
+  @deprecated
   def persistToMongo(arrivalMovement: ArrivalMovement): Future[WriteResult] = {
 
     val doc: JsObject = Json.toJson(arrivalMovement).as[JsObject]

--- a/app/services/ArrivalMovementService.scala
+++ b/app/services/ArrivalMovementService.scala
@@ -23,6 +23,7 @@ import cats._
 import cats.data._
 import cats.implicits._
 import com.google.inject.Inject
+import models.Arrival
 import models.ArrivalMovement
 import models.TimeStampedMessageXml
 import models.messages.MovementReferenceNumber
@@ -37,7 +38,7 @@ import scala.xml.NodeSeq
 class ArrivalMovementService @Inject()(arrivalIdRepository: ArrivalIdRepository)(implicit ec: ExecutionContext) {
   import ArrivalMovementService._
 
-  def makeArrivalMovement(eori: String): Reader[NodeSeq, Option[Future[ArrivalMovement]]] =
+  def makeArrivalMovement(eori: String): Reader[NodeSeq, Option[Future[Arrival]]] =
     for {
       date       <- dateOfPrepR
       time       <- timeOfPrepR
@@ -52,8 +53,7 @@ class ArrivalMovementService @Inject()(arrivalIdRepository: ArrivalIdRepository)
       } yield {
         arrivalIdRepository
           .nextId()
-          .map(_.index)
-          .map(ArrivalMovement(_, m, eori, Seq(TimeStampedMessageXml(d, t, xmlMessage))))
+          .map(Arrival(_, m, eori, Seq(TimeStampedMessageXml(d, t, xmlMessage))))
       }
     }
 }

--- a/it/services/repositories/ArrivalIdRepositorySpec.scala
+++ b/it/services/repositories/ArrivalIdRepositorySpec.scala
@@ -1,0 +1,54 @@
+package services.repositories
+
+import models.request.ArrivalId
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.{FreeSpec, MustMatchers}
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.libs.json.Json
+import reactivemongo.play.json.collection.JSONCollection
+import reactivemongo.play.json.ImplicitBSONHandlers.JsObjectDocumentWriter
+import repositories.ArrivalIdRepository
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class ArrivalIdRepositorySpec extends FreeSpec with MustMatchers with ScalaFutures with MongoSuite with GuiceOneAppPerSuite with IntegrationPatience {
+
+  private val service =  app.injector.instanceOf[ArrivalIdRepository]
+
+  "ArrivalIdRepository" - {
+
+    "must generate sequential ArrivalIds starting at 1 when no record exists within the database" in {
+
+      database.flatMap(_.drop()).futureValue
+
+      val first = service.nextId().futureValue
+      val second = service.nextId().futureValue
+
+      first mustBe ArrivalId(1)
+      second mustBe ArrivalId(2)
+    }
+
+    "must generate sequential ArrivalIds when a record exists within the database" in {
+
+      database.flatMap {
+        db =>
+          db.drop().flatMap {
+            _ =>
+              db.collection[JSONCollection](ArrivalIdRepository.collectionName)
+                .insert(ordered = false)
+                .one(
+                  Json.obj(
+                    "_id" -> "record_id",
+                    "last-index" -> 1
+                  ))
+          }
+      }.futureValue
+
+      val first = service.nextId().futureValue
+      val second = service.nextId().futureValue
+
+      first mustBe ArrivalId(2)
+      second mustBe ArrivalId(3)
+    }
+  }
+}

--- a/it/services/repositories/ArrivalMovementRepositorySpec.scala
+++ b/it/services/repositories/ArrivalMovementRepositorySpec.scala
@@ -1,10 +1,14 @@
 package services.repositories
 
 import generators.MessageGenerators
+import models.Arrival
 import models.ArrivalMovement
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.{FreeSpec, MustMatchers, OptionValues}
+import org.scalatest.concurrent.IntegrationPatience
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.FreeSpec
+import org.scalatest.MustMatchers
+import org.scalatest.OptionValues
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.Application
@@ -13,43 +17,84 @@ import play.api.libs.json.Json
 import play.api.test.Helpers._
 import reactivemongo.play.json.ImplicitBSONHandlers.JsObjectDocumentWriter
 import reactivemongo.play.json.collection.JSONCollection
-import repositories.{ArrivalMovementRepository, CollectionNames}
+import repositories.ArrivalMovementRepository
+import repositories.CollectionNames
 import services.mocks.MockDateTimeService
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class ArrivalMovementRepositorySpec extends FreeSpec with MustMatchers with MongoSuite with FailOnUnindexedQueries with ScalaFutures with GuiceOneAppPerSuite with IntegrationPatience with MockDateTimeService with OptionValues with ScalaCheckPropertyChecks with MessageGenerators {
+class ArrivalMovementRepositorySpec
+    extends FreeSpec
+    with MustMatchers
+    with MongoSuite
+    with FailOnUnindexedQueries
+    with ScalaFutures
+    with IntegrationPatience
+    with MockDateTimeService
+    with OptionValues
+    with ScalaCheckPropertyChecks
+    with MessageGenerators {
 
-  private val eoriNumber: String = arbitrary[String].sample.value
+  private val eoriNumber: String                = arbitrary[String].sample.value
   private val arrivalMovement1: ArrivalMovement = arbitrary[ArrivalMovement].sample.value.ensuring(_.eoriNumber != eoriNumber)
   private val arrivalMovement2: ArrivalMovement = arbitrary[ArrivalMovement].sample.value.ensuring(_.eoriNumber != eoriNumber)
 
   private lazy val builder = new GuiceApplicationBuilder()
 
-  override protected def afterEach(): Unit = {
-    super.afterEach
+  override def beforeEach(): Unit = {
+    super.beforeEach()
     database.flatMap(_.drop()).futureValue
   }
 
   "ArrivalMovementRepository" - {
-    "must persist ArrivalMovement within mongoDB" in {
+    "insert" - {
+      "must persist ArrivalMovement within mongoDB" in {
 
-      val app: Application = builder.build()
+        val app: Application = builder.build()
 
-      running(app) {
-        started(app).futureValue
+        val arrival = arbitrary[Arrival].sample.value
 
-        val service: ArrivalMovementRepository = app.injector.instanceOf[ArrivalMovementRepository]
+        running(app) {
+          started(app).futureValue
 
-        service.persistToMongo(arrivalMovement1).futureValue
+          val repository = app.injector.instanceOf[ArrivalMovementRepository]
 
-        val selector = Json.obj("eoriNumber" -> arrivalMovement1.eoriNumber)
+          repository.insert(arrival).futureValue
 
-        val getValue: Option[ArrivalMovement] = database.flatMap { result =>
-          result.collection[JSONCollection](CollectionNames.ArrivalMovementCollection).find(selector, None).one[ArrivalMovement]
-        }.futureValue
+          val selector = Json.obj("eoriNumber" -> arrival.eoriNumber)
 
-        getValue.value mustBe arrivalMovement1
+          val result = database.flatMap {
+            result =>
+              result.collection[JSONCollection](CollectionNames.ArrivalMovementCollection).find(selector, None).one[Arrival]
+          }.futureValue
+
+          result.value mustBe arrival
+        }
+      }
+
+    }
+
+    "persistToMongo" - {
+      "must persist ArrivalMovement within mongoDB" in {
+
+        val app: Application = builder.build()
+
+        running(app) {
+          started(app).futureValue
+
+          val service: ArrivalMovementRepository = app.injector.instanceOf[ArrivalMovementRepository]
+
+          service.persistToMongo(arrivalMovement1).futureValue
+
+          val selector = Json.obj("eoriNumber" -> arrivalMovement1.eoriNumber)
+
+          val getValue: Option[ArrivalMovement] = database.flatMap {
+            result =>
+              result.collection[JSONCollection](CollectionNames.ArrivalMovementCollection).find(selector, None).one[ArrivalMovement]
+          }.futureValue
+
+          getValue.value mustBe arrivalMovement1
+        }
       }
     }
 
@@ -66,8 +111,9 @@ class ArrivalMovementRepositorySpec extends FreeSpec with MustMatchers with Mong
 
           val jsonArr = allMovements.map(Json.toJsObject(_))
 
-          database.flatMap { db =>
-            db.collection[JSONCollection](CollectionNames.ArrivalMovementCollection).insert(false).many(jsonArr)
+          database.flatMap {
+            db =>
+              db.collection[JSONCollection](CollectionNames.ArrivalMovementCollection).insert(false).many(jsonArr)
           }.futureValue
 
           val result: Seq[ArrivalMovement] = service.fetchAllMovements(arrivalMovement1.eoriNumber).futureValue
@@ -88,8 +134,9 @@ class ArrivalMovementRepositorySpec extends FreeSpec with MustMatchers with Mong
 
           val jsonArr = allMovements.map(Json.toJsObject(_))
 
-          database.flatMap { db =>
-            db.collection[JSONCollection](CollectionNames.ArrivalMovementCollection).insert(false).many(jsonArr)
+          database.flatMap {
+            db =>
+              db.collection[JSONCollection](CollectionNames.ArrivalMovementCollection).insert(false).many(jsonArr)
           }.futureValue
 
           val result: Seq[ArrivalMovement] = service.fetchAllMovements(eoriNumber).futureValue
@@ -101,4 +148,3 @@ class ArrivalMovementRepositorySpec extends FreeSpec with MustMatchers with Mong
   }
 
 }
-

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -41,7 +41,7 @@ trait SpecBase extends FreeSpec with MustMatchers with MockitoSugar with ScalaFu
 
   def fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("", "")
 
-  protected def applicationBuilder: GuiceApplicationBuilder =
+  protected def baseApplicationBuilder: GuiceApplicationBuilder =
     new GuiceApplicationBuilder()
       .overrides(
         bind[IdentifierAction].to[FakeIdentifierAction]

--- a/test/controllers/ArrivalNotificationControllerSpec.scala
+++ b/test/controllers/ArrivalNotificationControllerSpec.scala
@@ -49,7 +49,7 @@ class ArrivalNotificationControllerSpec extends SpecBase with ScalaCheckProperty
   private val mockXmlValidationService: XmlValidationService     = mock[XmlValidationService]
 
   private val application = {
-    applicationBuilder
+    baseApplicationBuilder
       .overrides(bind[MessageConnector].toInstance(mockMessageConnector))
       .overrides(bind[DatabaseService].toInstance(mockDatabaseService))
       .overrides(bind[SubmissionModelService].toInstance(mockSubmissionModelService))

--- a/test/controllers/MovementsControllerSpec.scala
+++ b/test/controllers/MovementsControllerSpec.scala
@@ -22,7 +22,7 @@ import java.time.LocalTime
 import base.SpecBase
 import generators.MessageGenerators
 import models.ArrivalMovement
-import models.request.InternalReferenceId
+import models.request.ArrivalId
 import org.mockito.Matchers.any
 import org.mockito.Mockito.reset
 import org.mockito.Mockito._
@@ -33,39 +33,33 @@ import play.api.inject.bind
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import repositories.ArrivalIdRepository
 import repositories.ArrivalMovementRepository
-import repositories.FailedCreatingNextInternalReferenceId
-import services.DatabaseService
 import utils.Format
+import org.scalacheck.Arbitrary.arbitrary
 
 import scala.concurrent.Future
 
 class MovementsControllerSpec extends SpecBase with ScalaCheckPropertyChecks with MessageGenerators with BeforeAndAfterEach with IntegrationPatience {
 
-  private val mockArrivalMovementRepository = mock[ArrivalMovementRepository]
-
-  def applicationMovementsControllerSpec =
-    applicationBuilder
-      .overrides(
-        bind[ArrivalMovementRepository].toInstance(mockArrivalMovementRepository)
-      )
-
-  override protected def beforeEach(): Unit = {
-    super.beforeEach()
-    reset(mockArrivalMovementRepository)
-  }
-
   "MovementsController" - {
 
-    "createMovement" ignore {
+    "createMovement" - {
 
       "must return Ok and create movement" in {
-        val mockDatabaseService = mock[DatabaseService]
-        val ir                  = InternalReferenceId(1)
-        when(mockDatabaseService.getInternalReferenceId).thenReturn(Future.successful(Right(ir)))
-        when(mockDatabaseService.saveArrivalMovement(any())).thenReturn(Future.successful(Right(fakeWriteResult)))
+        val mockArrivalIdRepository       = mock[ArrivalIdRepository]
+        val mockArrivalMovementRepository = mock[ArrivalMovementRepository]
+        val arrivalId                     = ArrivalId(1)
 
-        val application = applicationMovementsControllerSpec.overrides(bind[DatabaseService].toInstance(mockDatabaseService)).build()
+        when(mockArrivalIdRepository.nextId()).thenReturn(Future.successful(arrivalId))
+        when(mockArrivalMovementRepository.insert(any())).thenReturn(Future.successful(()))
+
+        val application = baseApplicationBuilder
+          .overrides(
+            bind[ArrivalIdRepository].toInstance(mockArrivalIdRepository),
+            bind[ArrivalMovementRepository].toInstance(mockArrivalMovementRepository)
+          )
+          .build()
 
         running(application) {
 
@@ -88,20 +82,24 @@ class MovementsControllerSpec extends SpecBase with ScalaCheckPropertyChecks wit
           val result = route(application, request).value
 
           status(result) mustEqual ACCEPTED
-          header("Location", result).value must be(ir.index.toString) // TODO: This needs to be the actual resource location
-          verify(mockDatabaseService, times(1)).saveArrivalMovement(any())
+          header("Location", result).value must be(arrivalId.index.toString) // TODO: This needs to be the actual resource location
+          verify(mockArrivalMovementRepository, times(1)).insert(any())
 
         }
       }
 
       "must return InternalServerError if the InternalReference generation fails" in {
-        val mockDatabaseService = mock[DatabaseService]
-        when(mockDatabaseService.getInternalReferenceId).thenReturn(Future.successful(Left(FailedCreatingNextInternalReferenceId)))
+        val mockArrivalIdRepository       = mock[ArrivalIdRepository]
+        val mockArrivalMovementRepository = mock[ArrivalMovementRepository]
 
-        val application =
-          applicationMovementsControllerSpec
-            .overrides(bind[DatabaseService].toInstance(mockDatabaseService))
-            .build()
+        when(mockArrivalIdRepository.nextId()).thenReturn(Future.failed(new Exception))
+
+        val application = baseApplicationBuilder
+          .overrides(
+            bind[ArrivalIdRepository].toInstance(mockArrivalIdRepository),
+            bind[ArrivalMovementRepository].toInstance(mockArrivalMovementRepository)
+          )
+          .build()
 
         running(application) {
           val dateOfPrep = LocalDate.now()
@@ -124,17 +122,24 @@ class MovementsControllerSpec extends SpecBase with ScalaCheckPropertyChecks wit
 
           status(result) mustEqual INTERNAL_SERVER_ERROR
           header("Location", result) must not be (defined)
+          verify(mockArrivalMovementRepository, times(0)).insert(any())
         }
       }
 
       "must return InternalServerError if the database fails to create a new Arrival Movement" in {
-        val mockDatabaseService = mock[DatabaseService]
-        when(mockDatabaseService.getInternalReferenceId).thenReturn(Future.successful(Left(FailedCreatingNextInternalReferenceId)))
+        val mockArrivalIdRepository       = mock[ArrivalIdRepository]
+        val mockArrivalMovementRepository = mock[ArrivalMovementRepository]
+        val arrivalId                     = ArrivalId(1)
 
-        val application =
-          applicationMovementsControllerSpec
-            .overrides(bind[DatabaseService].toInstance(mockDatabaseService))
-            .build()
+        when(mockArrivalIdRepository.nextId()).thenReturn(Future.successful(arrivalId))
+        when(mockArrivalMovementRepository.insert(any())).thenReturn(Future.failed(new Exception))
+
+        val application = baseApplicationBuilder
+          .overrides(
+            bind[ArrivalIdRepository].toInstance(mockArrivalIdRepository),
+            bind[ArrivalMovementRepository].toInstance(mockArrivalMovementRepository)
+          )
+          .build()
 
         running(application) {
           val dateOfPrep = LocalDate.now()
@@ -161,12 +166,15 @@ class MovementsControllerSpec extends SpecBase with ScalaCheckPropertyChecks wit
       }
 
       "must return BadRequest if the payload is malformed" in {
-        val mockDatabaseService = mock[DatabaseService]
-        when(mockDatabaseService.getInternalReferenceId).thenReturn(Future.successful(Left(FailedCreatingNextInternalReferenceId)))
+        val mockArrivalIdRepository       = mock[ArrivalIdRepository]
+        val mockArrivalMovementRepository = mock[ArrivalMovementRepository]
 
         val application =
-          applicationMovementsControllerSpec
-            .overrides(bind[DatabaseService].toInstance(mockDatabaseService))
+          baseApplicationBuilder
+            .overrides(
+              bind[ArrivalIdRepository].toInstance(mockArrivalIdRepository),
+              bind[ArrivalMovementRepository].toInstance(mockArrivalMovementRepository)
+            )
             .build()
 
         running(application) {
@@ -184,6 +192,8 @@ class MovementsControllerSpec extends SpecBase with ScalaCheckPropertyChecks wit
 
           status(result) mustEqual BAD_REQUEST
           header("Location", result) must not be (defined)
+          verify(mockArrivalIdRepository, times(0)).nextId()
+          verify(mockArrivalMovementRepository, times(0)).insert(any())
         }
       }
     }
@@ -191,11 +201,16 @@ class MovementsControllerSpec extends SpecBase with ScalaCheckPropertyChecks wit
     "getMovements" - {
 
       "must return Ok and retrieve movements" in {
-        forAll(seqWithMaxLength[ArrivalMovement](10)) {
-          arrivalMovements =>
-            val application = applicationMovementsControllerSpec.build()
+        val mockArrivalMovementRepository = mock[ArrivalMovementRepository]
 
-            running(application) {
+        val application =
+          baseApplicationBuilder
+            .overrides(bind[ArrivalMovementRepository].toInstance(mockArrivalMovementRepository))
+            .build()
+
+        running(application) {
+          forAll(seqWithMaxLength[ArrivalMovement](10)) {
+            arrivalMovements =>
               when(mockArrivalMovementRepository.fetchAllMovements(any())).thenReturn(Future.successful(arrivalMovements))
 
               val expectedResult = arrivalMovements.map(_.messages.head)
@@ -206,16 +221,23 @@ class MovementsControllerSpec extends SpecBase with ScalaCheckPropertyChecks wit
 
               status(result) mustEqual OK
               contentAsJson(result) mustEqual Json.toJson(expectedResult)
-            }
+
+              reset(mockArrivalMovementRepository)
+          }
         }
       }
 
       "must return an INTERNAL_SERVER_ERROR on fail" in {
-        val application = applicationMovementsControllerSpec.build()
+        val mockArrivalMovementRepository = mock[ArrivalMovementRepository]
+        when(mockArrivalMovementRepository.fetchAllMovements(any()))
+          .thenReturn(Future.failed(new Exception))
+
+        val application =
+          baseApplicationBuilder
+            .overrides(bind[ArrivalMovementRepository].toInstance(mockArrivalMovementRepository))
+            .build()
 
         running(application) {
-          when(mockArrivalMovementRepository.fetchAllMovements(any()))
-            .thenReturn(Future.failed(new Exception))
 
           val request = FakeRequest(GET, routes.MovementsController.getMovements().url)
 

--- a/test/controllers/MovementsControllerSpec.scala
+++ b/test/controllers/MovementsControllerSpec.scala
@@ -57,7 +57,7 @@ class MovementsControllerSpec extends SpecBase with ScalaCheckPropertyChecks wit
 
   "MovementsController" - {
 
-    "createMovement" - {
+    "createMovement" ignore {
 
       "must return Ok and create movement" in {
         val mockDatabaseService = mock[DatabaseService]

--- a/test/controllers/actions/IdentifierActionSpec.scala
+++ b/test/controllers/actions/IdentifierActionSpec.scala
@@ -111,7 +111,7 @@ class IdentifierActionSpec extends SpecBase {
       when(mockAuthConnector.authorise[Enrolments](any(), any())(any(), any()))
         .thenReturn(Future.successful(enrolmentsWithEori))
 
-      val application = applicationBuilder.build()
+      val application = baseApplicationBuilder.build()
 
       val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
       val appConfig   = application.injector.instanceOf[AppConfig]
@@ -128,7 +128,7 @@ class IdentifierActionSpec extends SpecBase {
       when(mockAuthConnector.authorise[Enrolments](any(), any())(any(), any()))
         .thenReturn(Future.successful(enrolmentsWithoutEori))
 
-      val application = applicationBuilder.build()
+      val application = baseApplicationBuilder.build()
       val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
       val appConfig   = application.injector.instanceOf[AppConfig]
 

--- a/test/services/ArrivalMovementServiceSpec.scala
+++ b/test/services/ArrivalMovementServiceSpec.scala
@@ -20,13 +20,11 @@ import java.time.LocalDate
 import java.time.LocalTime
 
 import base.SpecBase
-import models.ArrivalMovement
+import models.Arrival
 import models.TimeStampedMessageXml
 import models.messages.MovementReferenceNumber
 import models.request.ArrivalId
-import models.request.InternalReferenceId
 import org.mockito.Mockito.when
-import org.scalatest.EitherValues
 import org.scalatest.concurrent.IntegrationPatience
 import play.api.inject.bind
 import repositories.ArrivalIdRepository
@@ -39,15 +37,15 @@ class ArrivalMovementServiceSpec extends SpecBase with IntegrationPatience {
   "makeArrivalMovement" - {
     "creates an arrival movement with an internal ref number and a mrn, date and time of creation from the message submitted" in {
 
-      val id                    = ArrivalId(1)
-      val mrn                   = "MRN"
-      val eori                  = "eoriNumber"
-      val dateOfPrep: LocalDate = LocalDate.now()
-      val timeOfPrep: LocalTime = LocalTime.of(1, 1)
+      val id         = ArrivalId(1)
+      val mrn        = "MRN"
+      val eori       = "eoriNumber"
+      val dateOfPrep = LocalDate.now()
+      val timeOfPrep = LocalTime.of(1, 1)
 
       val mockArrivalIdRepository = mock[ArrivalIdRepository]
       when(mockArrivalIdRepository.nextId).thenReturn(Future.successful(id))
-      val application = applicationBuilder
+      val application = baseApplicationBuilder
         .overrides(
           bind[ArrivalIdRepository].toInstance(mockArrivalIdRepository)
         )
@@ -66,8 +64,8 @@ class ArrivalMovementServiceSpec extends SpecBase with IntegrationPatience {
           </CC007A>
         </transitRequest>
 
-      val expectedArrivalMovement: ArrivalMovement = ArrivalMovement(
-        internalReferenceId = id.index,
+      val expectedArrival = Arrival(
+        arrivalId = id,
         movementReferenceNumber = mrn,
         eoriNumber = eori,
         messages = Seq(
@@ -75,7 +73,7 @@ class ArrivalMovementServiceSpec extends SpecBase with IntegrationPatience {
         )
       )
 
-      service.makeArrivalMovement(eori)(movement).value.futureValue mustEqual expectedArrivalMovement
+      service.makeArrivalMovement(eori)(movement).value.futureValue mustEqual expectedArrival
     }
   }
 


### PR DESCRIPTION
- Simplify the explicit error handling when reading and writing to Mongo
- Refactor controller to need less case handling for errors
- Rename identifier for arrival movement to arrivalId
