### PR TITLE
Changes to how we persist an Arrival 

### DIFF
--- a/app/models/Arrival.scala
+++ b/app/models/Arrival.scala
@@ -17,13 +17,29 @@
 package models
 
 import models.request.ArrivalId
-import play.api.libs.json.Json
-import play.api.libs.json.OFormat
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
 
 case class Arrival(arrivalId: ArrivalId, movementReferenceNumber: String, eoriNumber: String, state: State, messages: Seq[MovementMessage])
 
 object Arrival {
 
-  implicit val formatsArrival: OFormat[Arrival] = Json.format[Arrival]
+  implicit val readsArrival: Reads[Arrival] =
+    (
+      (__ \ "_id").read[ArrivalId] and
+        (__ \ "movementReferenceNumber").read[String] and
+        (__ \ "eoriNumber").read[String] and
+        (__ \ "state").read[State] and
+        (__ \ "messages").read[Seq[MovementMessage]]
+    )(Arrival.apply _)
+
+  implicit val writesArrival: OWrites[Arrival] =
+    (
+      (__ \ "_id").write[ArrivalId] and
+        (__ \ "movementReferenceNumber").write[String] and
+        (__ \ "eoriNumber").write[String] and
+        (__ \ "state").write[State] and
+        (__ \ "messages").write[Seq[MovementMessage]]
+    )(unlift(Arrival.unapply))
 
 }

--- a/app/models/request/ArrivalId.scala
+++ b/app/models/request/ArrivalId.scala
@@ -15,11 +15,25 @@
  */
 
 package models.request
-import play.api.libs.json.Json
-import play.api.libs.json.OFormat
+import play.api.libs.json._
+
+import scala.util.Try
 
 case class ArrivalId(index: Int)
 
 object ArrivalId {
-  implicit val formatsArrivalId: OFormat[ArrivalId] = Json.format[ArrivalId]
+  implicit val formatsArrivalId: Format[ArrivalId] = new Format[ArrivalId] {
+    override def reads(json: JsValue): JsResult[ArrivalId] = json match {
+      case JsNumber(number) =>
+        Try(number.toInt)
+          .map(ArrivalId(_))
+          .map(JsSuccess(_))
+          .getOrElse(JsError("Error in converting JsNumber to an Int"))
+
+      case e =>
+        JsError(s"Error in deserialization of Json value to an ArrivalId, expected JsNumber got ${e.getClass}")
+    }
+
+    override def writes(o: ArrivalId): JsNumber = JsNumber(o.index)
+  }
 }

--- a/app/repositories/ArrivalIdRepository.scala
+++ b/app/repositories/ArrivalIdRepository.scala
@@ -34,9 +34,9 @@ class ArrivalIdRepository @Inject()(mongo: ReactiveMongoApi) {
 
   private val collectionName: String = ArrivalIdRepository.collectionName
 
-  private val indexKeyReads: Reads[Int] = {
+  private val indexKeyReads: Reads[ArrivalId] = {
     import play.api.libs.json._
-    (__ \ lastIndexKey).read[Int]
+    (__ \ lastIndexKey).read[ArrivalId]
   }
 
   private def collection: Future[JSONCollection] =
@@ -55,7 +55,6 @@ class ArrivalIdRepository @Inject()(mongo: ReactiveMongoApi) {
         .map(
           x =>
             x.result(indexKeyReads)
-              .map(increment => ArrivalId(increment))
               .getOrElse(throw new Exception(s"Unable to generate ArrivalId")))
     )
   }

--- a/app/repositories/ArrivalMovementRepository.scala
+++ b/app/repositories/ArrivalMovementRepository.scala
@@ -60,16 +60,12 @@ class ArrivalMovementRepository @Inject()(cc: ControllerComponents, mongo: React
   private def collection: Future[JSONCollection] =
     mongo.database.map(_.collection[JSONCollection](collectionName))
 
-  def insert(arrival: Arrival): Future[Unit] = {
-
-    val mongoId = Json.obj("_id" -> arrival.arrivalId)
-
+  def insert(arrival: Arrival): Future[Unit] =
     collection.flatMap {
       _.insert(false)
-        .one(Json.toJsObject(arrival) ++ mongoId)
+        .one(Json.toJsObject(arrival))
         .map(_ => ())
     }
-  }
 
   def get(arrivalId: ArrivalId): Future[Option[Arrival]] = {
 

--- a/it/services/repositories/ArrivalMovementRepositorySpec.scala
+++ b/it/services/repositories/ArrivalMovementRepositorySpec.scala
@@ -1,14 +1,22 @@
 package services.repositories
 
-import java.time.{LocalDate, LocalTime}
+import java.time.LocalDate
+import java.time.LocalTime
 
 import generators.MessageGenerators
+import models.Arrival
+import models.ArrivalMovement
+import models.MessageType
+import models.MovementMessage
+import models.State
 import models.request.ArrivalId
-import models.{Arrival, ArrivalMovement, MessageType, MovementMessage, State}
 import org.scalacheck.Arbitrary.arbitrary
+import org.scalatest.EitherValues
+import org.scalatest.FreeSpec
+import org.scalatest.MustMatchers
+import org.scalatest.OptionValues
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{EitherValues, FreeSpec, MustMatchers, OptionValues}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -22,7 +30,8 @@ import services.mocks.MockDateTimeService
 import utils.Format
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.{Failure, Success}
+import scala.util.Failure
+import scala.util.Success
 
 class ArrivalMovementRepositorySpec
     extends FreeSpec
@@ -121,7 +130,7 @@ class ArrivalMovementRepositorySpec
           </CC025A>
 
         val goodsReleasedMessage = MovementMessage(dateOfPrep, timeOfPrep, MessageType.GoodsReleased, messageBody)
-        val newState = State.GoodsReleased
+        val newState             = State.GoodsReleased
 
         running(app) {
           started(app).futureValue
@@ -165,7 +174,7 @@ class ArrivalMovementRepositorySpec
           </CC025A>
 
         val goodsReleasedMessage = MovementMessage(dateOfPrep, timeOfPrep, MessageType.GoodsReleased, messageBody)
-        val newState = State.GoodsReleased
+        val newState             = State.GoodsReleased
 
         running(app) {
           started(app).futureValue


### PR DESCRIPTION
- Change ArrivalId reads and writes to JsNumber
- Change ArrivalId Json reads and writes to write the arrival field as the "_id" primary index
- Refactor ArrivalIdRepository to read ArrivalId directly
