### PR TITLE
Refactor MessageId and encapsulate Message and MessageId association in Arrival

### DIFF
--- a/app/controllers/MessagesController.scala
+++ b/app/controllers/MessagesController.scala
@@ -59,13 +59,12 @@ class MessagesController @Inject()(
             .makeMovementMessageWithStatus(request.arrival.nextMessageCorrelationId, MessageType.UnloadingRemarks)(request.body)
             .map {
               message =>
-                val messageId = new MessageId(request.arrival.messages.length)
                 submitMessageService
-                  .submitMessage(arrivalId, messageId, message, ArrivalStatus.UnloadingRemarksSubmitted)
+                  .submitMessage(arrivalId, request.arrival.nextMessageId, message, ArrivalStatus.UnloadingRemarksSubmitted)
                   .map {
                     case SubmissionProcessingResult.SubmissionSuccess =>
                       Accepted("Message accepted")
-                        .withHeaders("Location" -> routes.MessagesController.getMessage(request.arrival.arrivalId, messageId).url)
+                        .withHeaders("Location" -> routes.MessagesController.getMessage(request.arrival.arrivalId, request.arrival.nextMessageId).url)
 
                     case SubmissionProcessingResult.SubmissionFailureInternal =>
                       InternalServerError

--- a/app/models/Arrival.scala
+++ b/app/models/Arrival.scala
@@ -32,7 +32,10 @@ case class Arrival(
   updated: LocalDateTime,
   messages: NonEmptyList[MovementMessage],
   nextMessageCorrelationId: Int
-)
+) {
+  lazy val currentMessageId: MessageId = MessageId.fromMessageIdValue(messages.length)
+  lazy val nextMessageId: MessageId    = MessageId.fromIndex(messages.length)
+}
 
 object Arrival {
 

--- a/app/models/Arrival.scala
+++ b/app/models/Arrival.scala
@@ -33,8 +33,12 @@ case class Arrival(
   messages: NonEmptyList[MovementMessage],
   nextMessageCorrelationId: Int
 ) {
-  lazy val currentMessageId: MessageId = MessageId.fromMessageIdValue(messages.length)
-  lazy val nextMessageId: MessageId    = MessageId.fromIndex(messages.length)
+
+  lazy val nextMessageId: MessageId = MessageId.fromIndex(messages.length)
+
+  lazy val messagesWithId: NonEmptyList[(MovementMessage, MessageId)] =
+    messages.mapWithIndex(_ -> MessageId.fromIndex(_))
+
 }
 
 object Arrival {

--- a/app/models/MessageId.scala
+++ b/app/models/MessageId.scala
@@ -27,6 +27,8 @@ import play.api.mvc.PathBindable
 import scala.util.Try
 
 final class MessageId private (val index: Int) {
+  override def toString: String = s"MessageId($index)"
+
   override def equals(obj: Any): Boolean = obj match {
     case x: MessageId => x.index == this.index
     case _            => false
@@ -35,7 +37,7 @@ final class MessageId private (val index: Int) {
 
 object MessageId {
 
-  def fromMessageIdValue(messageId: Int): MessageId = new MessageId(messageId - 1)
+  def fromMessageIdValue(messageId: Int): Option[MessageId] = if (messageId > 0) Some(new MessageId(messageId - 1)) else None
 
   def unapply(arg: MessageId): Some[Int] = Some(arg.index + 1)
 
@@ -46,9 +48,10 @@ object MessageId {
       implicitly[PathBindable[Int]]
         .bind(key, value)
         .fold(
-          Left(_), {
-            case messageId if (messageId > 0) => Right(fromMessageIdValue(messageId))
-            case x                            => Left(s"Invalid MessageId. The MessageId must be > 0, instead got $x")
+          Left(_),
+          fromMessageIdValue _ andThen {
+            case Some(messageId) => Right(messageId)
+            case x               => Left(s"Invalid MessageId. The MessageId must be > 0, instead got $x")
           }
         )
 

--- a/app/models/response/ResponseArrival.scala
+++ b/app/models/response/ResponseArrival.scala
@@ -53,7 +53,12 @@ object ResponseArrival {
           case (message, _) => message.optStatus == Some(SubmissionFailed)
         }
         .map {
-          case (message, count) => ResponseMovementMessage.build(arrival.arrivalId, new MessageId(count + 1), message)
+          case (message, count) =>
+            ResponseMovementMessage.build(
+              arrival.arrivalId,
+              MessageId.fromIndex(count + 1), // TODO: REVIEW THIS! OFF BY ONE?
+              message
+            )
         }
     )
 

--- a/app/models/response/ResponseArrival.scala
+++ b/app/models/response/ResponseArrival.scala
@@ -39,7 +39,12 @@ case class ResponseArrival(arrivalId: ArrivalId,
 
 object ResponseArrival {
 
-  def build(arrival: Arrival): ResponseArrival =
+  def build(arrival: Arrival): ResponseArrival = {
+    val validMessages =
+      arrival.messagesWithId
+        .filterNot(_._1.optStatus.contains(SubmissionFailed))
+        .map(messageData => ResponseMovementMessage.build(arrival.arrivalId, messageData._2, messageData._1))
+
     ResponseArrival(
       arrival.arrivalId,
       routes.MovementsController.getArrival(arrival.arrivalId).url,
@@ -48,19 +53,9 @@ object ResponseArrival {
       arrival.status,
       arrival.created,
       arrival.updated,
-      arrival.messages.toList.zipWithIndex
-        .filterNot {
-          case (message, _) => message.optStatus == Some(SubmissionFailed)
-        }
-        .map {
-          case (message, count) =>
-            ResponseMovementMessage.build(
-              arrival.arrivalId,
-              MessageId.fromIndex(count + 1), // TODO: REVIEW THIS! OFF BY ONE?
-              message
-            )
-        }
+      validMessages
     )
+  }
 
   implicit val writes: OWrites[ResponseArrival] = Json.writes[ResponseArrival]
 

--- a/app/services/SubmitMessageService.scala
+++ b/app/services/SubmitMessageService.scala
@@ -18,9 +18,9 @@ package services
 
 import java.time.OffsetDateTime
 
+import cats.implicits._
 import connectors.MessageConnector
 import javax.inject.Inject
-import play.api.Logger
 import models.Arrival
 import models.ArrivalId
 import models.ArrivalStatus
@@ -28,6 +28,7 @@ import models.MessageId
 import models.MessageStatus
 import models.MovementMessageWithStatus
 import models.SubmissionProcessingResult
+import play.api.Logger
 import repositories.ArrivalMovementRepository
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -83,8 +84,7 @@ class SubmitMessageService @Inject()(
       .insert(arrival)
       .flatMap {
         _ =>
-          val message   = arrival.messages.head.asInstanceOf[MovementMessageWithStatus]
-          val messageId = arrival.currentMessageId // TODO: We shouldn't need to do this. We should be able to get this from the MovementMessage
+          val (message, messageId) = arrival.messagesWithId.head.leftMap(_.asInstanceOf[MovementMessageWithStatus])
 
           messageConnector
             .post(arrival.arrivalId, message, OffsetDateTime.now)

--- a/app/services/SubmitMessageService.scala
+++ b/app/services/SubmitMessageService.scala
@@ -84,7 +84,7 @@ class SubmitMessageService @Inject()(
       .flatMap {
         _ =>
           val message   = arrival.messages.head.asInstanceOf[MovementMessageWithStatus]
-          val messageId = new MessageId(arrival.messages.length - 1)
+          val messageId = arrival.currentMessageId // TODO: We shouldn't need to do this. We should be able to get this from the MovementMessage
 
           messageConnector
             .post(arrival.arrivalId, message, OffsetDateTime.now)

--- a/it/repositories/ArrivalMovementRepositorySpec.scala
+++ b/it/repositories/ArrivalMovementRepositorySpec.scala
@@ -6,7 +6,7 @@ import cats.data.NonEmptyList
 import generators.ModelGenerators
 import models.ArrivalStatus.{ArrivalSubmitted, Initialized}
 import models.MessageStatus.{SubmissionPending, SubmissionSucceeded}
-import models.{Arrival, ArrivalId, ArrivalStatus, MessageType, MongoDateTimeFormats, MovementMessageWithStatus, MovementMessageWithoutStatus, MovementReferenceNumber}
+import models.{Arrival, ArrivalId, ArrivalStatus, MessageId, MessageType, MongoDateTimeFormats, MovementMessageWithStatus, MovementMessageWithoutStatus, MovementReferenceNumber}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import org.scalactic.source
@@ -255,7 +255,7 @@ class ArrivalMovementRepositorySpec
         val app: Application = builder.build()
 
         val arrival = arrivalWithOneMessage.sample.value.copy(status = ArrivalStatus.Initialized)
-        val messageId = new models.MessageId(0)
+        val messageId = MessageId.fromIndex(0)
 
         running(app) {
           started(app).futureValue
@@ -282,7 +282,7 @@ class ArrivalMovementRepositorySpec
         val app: Application = builder.build()
 
         val arrival = arrivalWithOneMessage.sample.value.copy(arrivalId = ArrivalId(1), status = Initialized)
-        val messageId = new models.MessageId(0)
+        val messageId =  MessageId.fromIndex(0)
 
         running(app) {
           started(app).futureValue

--- a/test/controllers/MessagesControllerSpec.scala
+++ b/test/controllers/MessagesControllerSpec.scala
@@ -86,7 +86,7 @@ class MessagesControllerSpec extends SpecBase with ScalaCheckPropertyChecks with
     2
   )
 
-  val messageId = new MessageId(0)
+  val messageId = MessageId.fromIndex(0)
 
   val arrivalId = arbitrary[ArrivalId].sample.value
 
@@ -136,9 +136,9 @@ class MessagesControllerSpec extends SpecBase with ScalaCheckPropertyChecks with
           val result  = route(application, request).value
 
           status(result) mustEqual ACCEPTED
-          header("Location", result).value must be(routes.MessagesController.getMessage(arrival.arrivalId, new MessageId(1)).url)
+          header("Location", result).value must be(routes.MessagesController.getMessage(arrival.arrivalId, MessageId.fromIndex(1)).url)
           verify(mockSubmitMessageService, times(1)).submitMessage(eqTo(arrival.arrivalId),
-                                                                   eqTo(new MessageId(1)),
+                                                                   eqTo(MessageId.fromIndex(1)),
                                                                    eqTo(movementMessge),
                                                                    eqTo(ArrivalStatus.UnloadingRemarksSubmitted))(any())
         }
@@ -298,11 +298,11 @@ class MessagesControllerSpec extends SpecBase with ScalaCheckPropertyChecks with
             .build()
 
         running(application) {
-          val request = FakeRequest(GET, routes.MessagesController.getMessage(arrival.arrivalId, new MessageId(0)).url)
+          val request = FakeRequest(GET, routes.MessagesController.getMessage(arrival.arrivalId, MessageId.fromIndex(0)).url)
           val result  = route(application, request).value
 
           status(result) mustEqual OK
-          contentAsJson(result) mustEqual Json.toJson(ResponseMovementMessage.build(arrival.arrivalId, new MessageId(0), message))
+          contentAsJson(result) mustEqual Json.toJson(ResponseMovementMessage.build(arrival.arrivalId, MessageId.fromIndex(0), message))
         }
       }
 
@@ -320,11 +320,11 @@ class MessagesControllerSpec extends SpecBase with ScalaCheckPropertyChecks with
             .build()
 
         running(application) {
-          val request = FakeRequest(GET, routes.MessagesController.getMessage(arrival.arrivalId, new MessageId(0)).url)
+          val request = FakeRequest(GET, routes.MessagesController.getMessage(arrival.arrivalId, MessageId.fromIndex(0)).url)
           val result  = route(application, request).value
 
           status(result) mustEqual OK
-          contentAsJson(result) mustEqual Json.toJson(ResponseMovementMessage.build(arrival.arrivalId, new MessageId(0), message))
+          contentAsJson(result) mustEqual Json.toJson(ResponseMovementMessage.build(arrival.arrivalId, MessageId.fromIndex(0), message))
         }
       }
 
@@ -340,7 +340,7 @@ class MessagesControllerSpec extends SpecBase with ScalaCheckPropertyChecks with
               .build()
 
           running(application) {
-            val request = FakeRequest(GET, routes.MessagesController.getMessage(ArrivalId(1), new MessageId(0)).url)
+            val request = FakeRequest(GET, routes.MessagesController.getMessage(ArrivalId(1), MessageId.fromIndex(0)).url)
             val result  = route(application, request).value
 
             status(result) mustEqual NOT_FOUND
@@ -361,7 +361,7 @@ class MessagesControllerSpec extends SpecBase with ScalaCheckPropertyChecks with
               .build()
 
           running(application) {
-            val request = FakeRequest(GET, routes.MessagesController.getMessage(arrival.arrivalId, new MessageId(5)).url)
+            val request = FakeRequest(GET, routes.MessagesController.getMessage(arrival.arrivalId, MessageId.fromIndex(5)).url)
             val result  = route(application, request).value
 
             status(result) mustEqual NOT_FOUND
@@ -382,7 +382,7 @@ class MessagesControllerSpec extends SpecBase with ScalaCheckPropertyChecks with
               .build()
 
           running(application) {
-            val request = FakeRequest(GET, routes.MessagesController.getMessage(arrival.arrivalId, new MessageId(0)).url)
+            val request = FakeRequest(GET, routes.MessagesController.getMessage(arrival.arrivalId, MessageId.fromIndex(0)).url)
             val result  = route(application, request).value
 
             status(result) mustEqual NOT_FOUND
@@ -403,7 +403,7 @@ class MessagesControllerSpec extends SpecBase with ScalaCheckPropertyChecks with
               .build()
 
           running(application) {
-            val request = FakeRequest(GET, routes.MessagesController.getMessage(arrival.arrivalId, new MessageId(0)).url)
+            val request = FakeRequest(GET, routes.MessagesController.getMessage(arrival.arrivalId, MessageId.fromIndex(0)).url)
             val result  = route(application, request).value
 
             status(result) mustEqual NOT_FOUND
@@ -421,7 +421,7 @@ class MessagesControllerSpec extends SpecBase with ScalaCheckPropertyChecks with
           val message = Arbitrary.arbitrary[MovementMessageWithStatus].sample.value.copy(status = SubmissionSucceeded)
           val arrival = Arbitrary.arbitrary[Arrival].sample.value.copy(messages = NonEmptyList.one(message), eoriNumber = "eori")
 
-          val expectedMessages = ResponseMovementMessage.build(arrival.arrivalId, new MessageId(1), message)
+          val expectedMessages = ResponseMovementMessage.build(arrival.arrivalId, MessageId.fromIndex(1), message)
           val expectedArrival  = ResponseArrival.build(arrival).copy(messages = Seq(expectedMessages))
 
           val mockArrivalMovementRepository = mock[ArrivalMovementRepository]
@@ -447,7 +447,7 @@ class MessagesControllerSpec extends SpecBase with ScalaCheckPropertyChecks with
           val message2 = Arbitrary.arbitrary[MovementMessageWithStatus].sample.value.copy(status = SubmissionFailed)
           val arrival  = Arbitrary.arbitrary[Arrival].sample.value.copy(messages = NonEmptyList.of(message1, message2), eoriNumber = "eori")
 
-          val expectedMessages = ResponseMovementMessage.build(arrival.arrivalId, new MessageId(1), message1)
+          val expectedMessages = ResponseMovementMessage.build(arrival.arrivalId, MessageId.fromIndex(1), message1)
           val expectedArrival  = ResponseArrival.build(arrival).copy(messages = Seq(expectedMessages))
 
           val mockArrivalMovementRepository = mock[ArrivalMovementRepository]
@@ -476,8 +476,8 @@ class MessagesControllerSpec extends SpecBase with ScalaCheckPropertyChecks with
 
           val arrival = Arbitrary.arbitrary[Arrival].sample.value.copy(messages = NonEmptyList.of(message1, message2, message3), eoriNumber = "eori")
 
-          val expectedMessage1 = ResponseMovementMessage.build(arrival.arrivalId, new MessageId(1), message1)
-          val expectedMessage3 = ResponseMovementMessage.build(arrival.arrivalId, new MessageId(3), message3)
+          val expectedMessage1 = ResponseMovementMessage.build(arrival.arrivalId, MessageId.fromIndex(1), message1)
+          val expectedMessage3 = ResponseMovementMessage.build(arrival.arrivalId, MessageId.fromIndex(3), message3)
           val expectedArrival  = ResponseArrival.build(arrival).copy(messages = Seq(expectedMessage1, expectedMessage3))
 
           val mockArrivalMovementRepository = mock[ArrivalMovementRepository]

--- a/test/controllers/MessagesControllerSpec.scala
+++ b/test/controllers/MessagesControllerSpec.scala
@@ -421,7 +421,7 @@ class MessagesControllerSpec extends SpecBase with ScalaCheckPropertyChecks with
           val message = Arbitrary.arbitrary[MovementMessageWithStatus].sample.value.copy(status = SubmissionSucceeded)
           val arrival = Arbitrary.arbitrary[Arrival].sample.value.copy(messages = NonEmptyList.one(message), eoriNumber = "eori")
 
-          val expectedMessages = ResponseMovementMessage.build(arrival.arrivalId, MessageId.fromIndex(1), message)
+          val expectedMessages = ResponseMovementMessage.build(arrival.arrivalId, MessageId.fromMessageIdValue(1).value, message)
           val expectedArrival  = ResponseArrival.build(arrival).copy(messages = Seq(expectedMessages))
 
           val mockArrivalMovementRepository = mock[ArrivalMovementRepository]
@@ -434,8 +434,8 @@ class MessagesControllerSpec extends SpecBase with ScalaCheckPropertyChecks with
               .build()
 
           running(application) {
-            val request = FakeRequest(GET, routes.MessagesController.getMessages(arrival.arrivalId).url)
-            val result  = route(application, request).value
+            lazy val request = FakeRequest(GET, routes.MessagesController.getMessages(arrival.arrivalId).url)
+            val result       = route(application, request).value
 
             status(result) mustEqual OK
             contentAsJson(result) mustEqual Json.toJson(expectedArrival)
@@ -447,7 +447,7 @@ class MessagesControllerSpec extends SpecBase with ScalaCheckPropertyChecks with
           val message2 = Arbitrary.arbitrary[MovementMessageWithStatus].sample.value.copy(status = SubmissionFailed)
           val arrival  = Arbitrary.arbitrary[Arrival].sample.value.copy(messages = NonEmptyList.of(message1, message2), eoriNumber = "eori")
 
-          val expectedMessages = ResponseMovementMessage.build(arrival.arrivalId, MessageId.fromIndex(1), message1)
+          val expectedMessages = ResponseMovementMessage.build(arrival.arrivalId, MessageId.fromMessageIdValue(1).value, message1)
           val expectedArrival  = ResponseArrival.build(arrival).copy(messages = Seq(expectedMessages))
 
           val mockArrivalMovementRepository = mock[ArrivalMovementRepository]
@@ -476,8 +476,8 @@ class MessagesControllerSpec extends SpecBase with ScalaCheckPropertyChecks with
 
           val arrival = Arbitrary.arbitrary[Arrival].sample.value.copy(messages = NonEmptyList.of(message1, message2, message3), eoriNumber = "eori")
 
-          val expectedMessage1 = ResponseMovementMessage.build(arrival.arrivalId, MessageId.fromIndex(1), message1)
-          val expectedMessage3 = ResponseMovementMessage.build(arrival.arrivalId, MessageId.fromIndex(3), message3)
+          val expectedMessage1 = ResponseMovementMessage.build(arrival.arrivalId, MessageId.fromMessageIdValue(1).value, message1)
+          val expectedMessage3 = ResponseMovementMessage.build(arrival.arrivalId, MessageId.fromMessageIdValue(3).value, message3)
           val expectedArrival  = ResponseArrival.build(arrival).copy(messages = Seq(expectedMessage1, expectedMessage3))
 
           val mockArrivalMovementRepository = mock[ArrivalMovementRepository]

--- a/test/controllers/MovementsControllerSpec.scala
+++ b/test/controllers/MovementsControllerSpec.scala
@@ -293,7 +293,7 @@ class MovementsControllerSpec extends SpecBase with ScalaCheckPropertyChecks wit
             status(result) mustEqual ACCEPTED
             header("Location", result).value must be(routes.MovementsController.getArrival(initializedArrival.arrivalId).url)
             verify(mockSubmitMessageService, times(1)).submitMessage(eqTo(initializedArrival.arrivalId),
-                                                                     eqTo(new MessageId(1)),
+                                                                     eqTo(MessageId.fromIndex(1)),
                                                                      eqTo(expectedMessage),
                                                                      eqTo(ArrivalStatus.ArrivalSubmitted))(any())
           }
@@ -462,7 +462,7 @@ class MovementsControllerSpec extends SpecBase with ScalaCheckPropertyChecks wit
           status(result) mustEqual ACCEPTED
           header("Location", result).value must be(routes.MovementsController.getArrival(initializedArrival.arrivalId).url)
           verify(mockSubmitMessageService, times(1)).submitMessage(eqTo(initializedArrival.arrivalId),
-                                                                   eqTo(new MessageId(1)),
+                                                                   eqTo(MessageId.fromIndex(1)),
                                                                    eqTo(expectedMessage),
                                                                    eqTo(ArrivalStatus.ArrivalSubmitted))(any())
         }

--- a/test/generators/ModelGenerators.scala
+++ b/test/generators/ModelGenerators.scala
@@ -130,7 +130,7 @@ trait ModelGenerators extends BaseGenerators with JavaTimeGenerators {
 
   implicit lazy val arbitraryMessageId: Arbitrary[MessageId] =
     Arbitrary {
-      intsAboveValue(0).map(new MessageId(_))
+      intsAboveValue(0).map(MessageId.fromIndex)
     }
 
   implicit lazy val arbitraryFailure: Arbitrary[SubmissionFailure] =

--- a/test/models/ArrivalSpec.scala
+++ b/test/models/ArrivalSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import base.SpecBase
+import generators.ModelGenerators
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+
+class ArrivalSpec extends SpecBase with ScalaCheckDrivenPropertyChecks with ModelGenerators {
+
+  val arrivaGenerator: Gen[Arrival] =
+    for {
+      messages <- nonEmptyListOfMaxLength[MovementMessageWithStatus](20)
+      arrival  <- arbitrary[Arrival].map(_.copy(messages = messages))
+    } yield arrival
+
+  "nextMessageId returns a MessageId which has value that is 1 larger than the number of messages" in {
+    forAll(arrivaGenerator) {
+      arrival =>
+        (MessageId.unapply(arrival.nextMessageId).value - arrival.messages.length) mustEqual 1
+    }
+  }
+
+  "messageWithId returns a list with the message and the MessageId whose value is one more than the index" in {
+    forAll(arrivaGenerator) {
+      arrival =>
+        arrival.messagesWithId.zipWithIndex.toList.foreach {
+          case ((message, messageId), index) =>
+            message mustEqual arrival.messages.toList(index)
+            (MessageId.unapply(messageId).value - index) mustEqual 1
+        }
+    }
+  }
+
+}

--- a/test/models/MessageIdSpec.scala
+++ b/test/models/MessageIdSpec.scala
@@ -55,7 +55,7 @@ class MessageIdSpec extends FreeSpec with MustMatchers with ScalaCheckPropertyCh
     "must unbind and convert the index to the message id value" in {
       forAll(intsAboveValue(0)) {
         value =>
-          val messageId            = new MessageId(value)
+          val messageId            = MessageId.fromIndex(value)
           val expectedMessageIndex = (value + 1).toString
 
           pathBindable.unbind("key", messageId) mustEqual expectedMessageIndex

--- a/test/services/SubmitMessageServiceSpec.scala
+++ b/test/services/SubmitMessageServiceSpec.scala
@@ -64,7 +64,7 @@ class SubmitMessageServiceSpec extends SpecBase with ModelGenerators {
       </HEAHEA>
     </CC007A>
 
-  val messageId = new MessageId(0)
+  val messageId = MessageId.fromIndex(0)
 
   val movementMessage = MovementMessageWithStatus(
     localDateTime,


### PR DESCRIPTION
- Encapsulate the next message Id and message and it's Id in Arrival.
- Add smart constructor methods for MessageId.
