### PR TITLE
Move to Scala 2.12.11

### DIFF
--- a/app/config/ErrorHandler.scala
+++ b/app/config/ErrorHandler.scala
@@ -16,17 +16,15 @@
 
 package config
 
-import javax.inject.Inject
 import play.api.Logger
 import play.api.http.HttpErrorHandler
 import play.api.mvc.RequestHeader
 import play.api.mvc.Result
 import play.api.mvc.Results._
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-class ErrorHandler @Inject()()(implicit ec: ExecutionContext) extends HttpErrorHandler {
+class ErrorHandler extends HttpErrorHandler {
   override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {
     Logger.warn(s"[ErrorHandler][onClientError], error for (${request.method}) [${request.uri}] with status: $statusCode and message: $message")
     Future.successful(Status(statusCode)(message))

--- a/app/controllers/MessagesController.scala
+++ b/app/controllers/MessagesController.scala
@@ -23,7 +23,6 @@ import models.ArrivalId
 import models.ArrivalStatus
 import models.MessageId
 import models.MessageType
-import models.MovementMessage
 import models.SubmissionProcessingResult
 import models.MessageStatus.SubmissionFailed
 import models.request.ArrivalRequest

--- a/app/controllers/MessagesSummaryController.scala
+++ b/app/controllers/MessagesSummaryController.scala
@@ -26,14 +26,11 @@ import play.api.mvc.ControllerComponents
 import services.ArrivalMessageSummaryService
 import uk.gov.hmrc.play.bootstrap.controller.BackendController
 
-import scala.concurrent.ExecutionContext
-
 class MessagesSummaryController @Inject()(
   authenticateForRead: AuthenticatedGetArrivalForReadActionProvider,
   arrivalMessageSummaryService: ArrivalMessageSummaryService,
   cc: ControllerComponents
-)(implicit ec: ExecutionContext)
-    extends BackendController(cc) {
+) extends BackendController(cc) {
 
   def messagesSummary(arrivalId: ArrivalId): Action[AnyContent] = authenticateForRead(arrivalId) {
     implicit request =>

--- a/app/controllers/MovementsController.scala
+++ b/app/controllers/MovementsController.scala
@@ -26,7 +26,6 @@ import models.MessageStatus.SubmissionSucceeded
 import models.ArrivalId
 import models.ArrivalStatus
 import models.ResponseArrivals
-import models.MessageId
 import models.MessageType
 import models.MovementMessage
 import models.SubmissionProcessingResult

--- a/app/controllers/NCTSMessageController.scala
+++ b/app/controllers/NCTSMessageController.scala
@@ -18,14 +18,13 @@ package controllers
 
 import controllers.actions.GetArrivalForWriteActionProvider
 import javax.inject.Inject
+import models.SubmissionProcessingResult._
 import models.ArrivalRejectedResponse
 import models.GoodsReleasedResponse
 import models.MessageResponse
 import models.MessageSender
 import models.MessageType
-import models.SubmissionProcessingResult
 import models.UnloadingPermissionResponse
-import models.SubmissionProcessingResult._
 import play.api.Logger
 import play.api.mvc.Action
 import play.api.mvc.ControllerComponents

--- a/app/controllers/actions/GetArrivalForWriteActionProvider.scala
+++ b/app/controllers/actions/GetArrivalForWriteActionProvider.scala
@@ -21,9 +21,6 @@ import models.ArrivalId
 import models.request.ArrivalRequest
 import play.api.mvc.ActionBuilder
 import play.api.mvc.AnyContent
-import play.api.mvc.BodyParsers
-
-import scala.concurrent.ExecutionContext
 
 class GetArrivalForWriteActionProvider @Inject()(
   lock: LockActionProvider,

--- a/app/controllers/actions/LockAction.scala
+++ b/app/controllers/actions/LockAction.scala
@@ -18,20 +18,13 @@ package controllers.actions
 
 import javax.inject.Inject
 import models.ArrivalId
-import play.api.mvc.ActionBuilder
-import play.api.mvc.ActionFunction
-import play.api.mvc.AnyContent
-import play.api.mvc.BodyParsers
-import play.api.mvc.Request
-import play.api.mvc.Result
+import play.api.mvc._
 import play.api.mvc.Results.InternalServerError
 import play.api.mvc.Results.Locked
 import repositories.LockRepository
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import scala.util.Failure
-import scala.util.Success
 
 private[actions] class LockActionProvider @Inject()(
   lockRepository: LockRepository,

--- a/app/controllers/testOnly/TestOnlyController.scala
+++ b/app/controllers/testOnly/TestOnlyController.scala
@@ -27,7 +27,6 @@ import repositories.ArrivalMovementRepository
 import uk.gov.hmrc.play.bootstrap.controller.BackendController
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 
 class TestOnlyController @Inject()(override val messagesApi: MessagesApi, mongo: ReactiveMongoApi, cc: ControllerComponents)(implicit ec: ExecutionContext)
     extends BackendController(cc) {

--- a/app/models/Arrival.scala
+++ b/app/models/Arrival.scala
@@ -19,7 +19,6 @@ package models
 import java.time.LocalDateTime
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
-import cats._
 import cats.data._
 import cats.implicits._
 

--- a/app/models/ArrivalModifier.scala
+++ b/app/models/ArrivalModifier.scala
@@ -26,7 +26,7 @@ object ArrivalModifier {
 
   def apply[A: ArrivalModifier]: ArrivalModifier[A] = implicitly[ArrivalModifier[A]]
 
-  def apply[A](fn: A => JsObject): ArrivalModifier[A] = new ArrivalModifier[A] {
+  def instance[A](fn: A => JsObject): ArrivalModifier[A] = new ArrivalModifier[A] {
     override def toJson(a: A): JsObject = fn(a)
   }
 

--- a/app/models/ArrivalUpdate.scala
+++ b/app/models/ArrivalUpdate.scala
@@ -17,8 +17,6 @@
 package models
 
 import cats._
-import cats.data._
-import cats.implicits._
 import play.api.libs.json.JsObject
 import play.api.libs.json.Json
 import play.api.libs.json.Writes

--- a/app/models/MessageId.scala
+++ b/app/models/MessageId.scala
@@ -16,15 +16,7 @@
 
 package models
 
-import play.api.libs.json.Format
-import play.api.libs.json.JsError
-import play.api.libs.json.JsNumber
-import play.api.libs.json.JsResult
-import play.api.libs.json.JsSuccess
-import play.api.libs.json.JsValue
 import play.api.mvc.PathBindable
-
-import scala.util.Try
 
 final class MessageId private (val index: Int) {
   override def toString: String = s"MessageId($index)"

--- a/app/models/response/ResponseArrival.scala
+++ b/app/models/response/ResponseArrival.scala
@@ -22,7 +22,6 @@ import controllers.routes
 import models.Arrival
 import models.ArrivalId
 import models.ArrivalStatus
-import models.MessageStatus.SubmissionFailed
 import models.MovementReferenceNumber
 import play.api.libs.json.Json
 import play.api.libs.json.OWrites
@@ -33,16 +32,11 @@ case class ResponseArrival(arrivalId: ArrivalId,
                            movementReferenceNumber: MovementReferenceNumber,
                            status: ArrivalStatus,
                            created: LocalDateTime,
-                           updated: LocalDateTime) {}
+                           updated: LocalDateTime)
 
 object ResponseArrival {
 
-  def build(arrival: Arrival): ResponseArrival = {
-    val validMessages =
-      arrival.messagesWithId
-        .filterNot(_._1.optStatus.contains(SubmissionFailed))
-        .map(messageData => ResponseMovementMessage.build(arrival.arrivalId, messageData._2, messageData._1))
-
+  def build(arrival: Arrival): ResponseArrival =
     ResponseArrival(
       arrival.arrivalId,
       routes.MovementsController.getArrival(arrival.arrivalId).url,
@@ -52,7 +46,6 @@ object ResponseArrival {
       arrival.created,
       arrival.updated
     )
-  }
 
   implicit val writes: OWrites[ResponseArrival] = Json.writes[ResponseArrival]
 

--- a/app/models/response/ResponseArrivalWithMessages.scala
+++ b/app/models/response/ResponseArrivalWithMessages.scala
@@ -23,7 +23,6 @@ import models.MessageStatus.SubmissionFailed
 import models.Arrival
 import models.ArrivalId
 import models.ArrivalStatus
-import models.MessageId
 import models.MovementReferenceNumber
 import play.api.libs.json.Json
 import play.api.libs.json.OWrites

--- a/app/services/XmlMessageParser.scala
+++ b/app/services/XmlMessageParser.scala
@@ -20,7 +20,6 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 
-import cats._
 import cats.data._
 import cats.implicits._
 import models.MessageType

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ lazy val microservice = Project(appName, file("."))
   .settings(inConfig(IntegrationTest)(itSettings): _*)
   .settings(inConfig(IntegrationTest)(scalafmtSettings): _*)
   .settings(inConfig(Test)(testSettings): _*)
+  .settings(scalaVersion := "2.12.11")
   .settings(
     majorVersion := 0,
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,

--- a/it/repositories/MongoSuite.scala
+++ b/it/repositories/MongoSuite.scala
@@ -20,7 +20,6 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest._
 import play.api.{Application, Configuration}
 import reactivemongo.api._
-import repositories.ArrivalMovementRepository
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future

--- a/test/controllers/MovementsControllerSpec.scala
+++ b/test/controllers/MovementsControllerSpec.scala
@@ -32,21 +32,18 @@ import models.MessageStatus.SubmissionSucceeded
 import models.Arrival
 import models.ArrivalId
 import models.ArrivalStatus
-import models.ResponseArrivals
 import models.MessageId
 import models.MessageType
 import models.MovementMessageWithStatus
-import models.MovementMessageWithoutStatus
 import models.MovementReferenceNumber
+import models.ResponseArrivals
 import models.SubmissionProcessingResult
 import models.response.ResponseArrival
-import models.response.ResponseMovementMessage
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.{eq => eqTo}
 import org.mockito.Mockito._
-import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Arbitrary
-import org.scalacheck.Gen
+import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks

--- a/test/controllers/NCTSMessageControllerSpec.scala
+++ b/test/controllers/NCTSMessageControllerSpec.scala
@@ -28,7 +28,6 @@ import models.ArrivalId
 import models.ArrivalStatus
 import models.MessageSender
 import models.MessageType
-import models.MovementMessage
 import models.MovementMessageWithStatus
 import models.MovementReferenceNumber
 import models.SubmissionProcessingResult

--- a/test/controllers/actions/FakeAuthenticateAction.scala
+++ b/test/controllers/actions/FakeAuthenticateAction.scala
@@ -18,19 +18,15 @@ package controllers.actions
 
 import javax.inject.Inject
 import models.request.AuthenticatedRequest
-import play.api.mvc.ActionBuilder
-import play.api.mvc.ActionRefiner
-import play.api.mvc.AnyContent
-import play.api.mvc.DefaultActionBuilder
-import play.api.mvc.Request
-import play.api.mvc.Result
+import play.api.mvc._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
-class FakeAuthenticateActionProvider @Inject()(defaultActionBuilder: DefaultActionBuilder, auth: FakeAuthenticateAction)(
-  implicit executionContext: ExecutionContext)
-    extends AuthenticateActionProvider {
+class FakeAuthenticateActionProvider @Inject()(
+  defaultActionBuilder: DefaultActionBuilder,
+  auth: FakeAuthenticateAction
+) extends AuthenticateActionProvider {
 
   override def apply(): ActionBuilder[AuthenticatedRequest, AnyContent] =
     defaultActionBuilder andThen auth

--- a/test/controllers/actions/FakeAuthenticatedGetArrivalForReadActionProvider.scala
+++ b/test/controllers/actions/FakeAuthenticatedGetArrivalForReadActionProvider.scala
@@ -19,8 +19,6 @@ package controllers.actions
 import models.Arrival
 import models.ArrivalId
 import models.request.ArrivalRequest
-import models.request.AuthenticatedOptionalArrivalRequest
-import models.request.AuthenticatedRequest
 import org.scalatest.exceptions.TestFailedException
 import play.api.mvc._
 import play.api.test.Helpers._

--- a/test/models/ArrivalStatusSpec.scala
+++ b/test/models/ArrivalStatusSpec.scala
@@ -21,8 +21,6 @@ import generators.ModelGenerators
 import models.ArrivalStatus._
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import play.api.libs.json.JsObject
-import play.api.libs.json.JsString
 
 class ArrivalStatusSpec extends SpecBase with ScalaCheckDrivenPropertyChecks with ModelGenerators {
   "transition" - {

--- a/test/models/MessageIdSpec.scala
+++ b/test/models/MessageIdSpec.scala
@@ -17,12 +17,10 @@
 package models
 
 import generators.BaseGenerators
-import generators.ModelGenerators
-import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.EitherValues
+import org.scalatest.OptionValues
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import org.scalatest.OptionValues
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.mvc.PathBindable
 
@@ -46,8 +44,6 @@ class MessageIdSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChe
     "must not bind from a URL for all all message id values less than 1" in {
       forAll(intsBelowValue(1)) {
         value =>
-          val expectedMessageIndex = value - 1
-
           pathBindable.bind("key", value.toString).left.value
       }
     }

--- a/test/models/MessageStatusSpec.scala
+++ b/test/models/MessageStatusSpec.scala
@@ -18,16 +18,7 @@ package models
 
 import base.SpecBase
 import generators.ModelGenerators
-import models.ArrivalStatus._
-import models.MessageStatus.SubmissionFailed
-import models.MessageStatus.SubmissionPending
-import models.MessageStatus.SubmissionSucceeded
-import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck.Arbitrary
-import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import play.api.libs.json.JsObject
-import play.api.libs.json.JsString
 
 class MessageStatusSpec extends SpecBase with ScalaCheckDrivenPropertyChecks with ModelGenerators {
   // TODO: Add tests

--- a/test/models/MessageTypeSpec.scala
+++ b/test/models/MessageTypeSpec.scala
@@ -18,16 +18,9 @@ package models
 
 import base.SpecBase
 import generators.ModelGenerators
-import models.MessageType.ArrivalNotification
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import play.api.libs.json.JsError
-import play.api.libs.json.JsNull
-import play.api.libs.json.JsNumber
-import play.api.libs.json.JsString
-import play.api.libs.json.JsSuccess
-import play.api.libs.json.Json
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck.Gen
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import play.api.libs.json._
 
 class MessageTypeSpec extends SpecBase with ScalaCheckDrivenPropertyChecks with ModelGenerators {
 

--- a/test/services/ArrivalMessageSummaryServiceSpec.scala
+++ b/test/services/ArrivalMessageSummaryServiceSpec.scala
@@ -16,22 +16,19 @@
 
 package services
 
-import java.time.LocalDateTime
-
 import base.SpecBase
 import cats.data._
 import generators.ModelGenerators
 import models.MessageStatus._
+import models.MessageType._
 import models.Arrival
 import models.MessageId
-import models.MessageStatus
 import models.MessageType
 import models.MessagesSummary
 import models.MovementMessage
 import models.MovementMessageWithStatus
 import models.MovementMessageWithoutStatus
 import org.scalacheck.Arbitrary.arbitrary
-import models.MessageType._
 import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 

--- a/test/services/ArrivalMovementMessageServiceSpec.scala
+++ b/test/services/ArrivalMovementMessageServiceSpec.scala
@@ -88,7 +88,6 @@ class ArrivalMovementMessageServiceSpec extends SpecBase with IntegrationPatienc
 
     "returns None when the root node is not <CC007A>" in {
 
-      val id         = ArrivalId(1)
       val mrn        = MovementReferenceNumber("MRN")
       val eori       = "eoriNumber"
       val dateOfPrep = LocalDate.now()

--- a/test/services/SubmitMessageServiceSpec.scala
+++ b/test/services/SubmitMessageServiceSpec.scala
@@ -24,7 +24,6 @@ import base.SpecBase
 import cats.data.NonEmptyList
 import connectors.MessageConnector
 import generators.ModelGenerators
-import models.ArrivalStatus.ArrivalSubmitted
 import models.MessageStatus.SubmissionFailed
 import models.MessageStatus.SubmissionPending
 import models.MessageStatus.SubmissionSucceeded
@@ -332,7 +331,6 @@ class SubmitMessageServiceSpec extends SpecBase with ModelGenerators {
         val arrivalId       = arbitrary[ArrivalId].sample.value
         val messageId       = arbitrary[MessageId].sample.value
         val movementMessage = arbitrary[MovementMessageWithStatus].sample.value
-        val arrivalStatus   = arbitrary[ArrivalStatus].sample.value
         val mrn             = arbitrary[MovementReferenceNumber].sample.value
 
         val result = service.submitIe007Message(arrivalId, messageId, movementMessage, mrn)


### PR DESCRIPTION
- The move to Scala 2.12 which resolves an issue where the object types were not being widened and the implicit resolution rules were not using the widened type
- This new Scala version now reports warnings in the compilation output, which have been resolved
