### PR TITLE
CTCTRADERS-1859 Optimise query for all arrivals

### DIFF
--- a/app/controllers/MovementsController.scala
+++ b/app/controllers/MovementsController.scala
@@ -167,10 +167,7 @@ class MovementsController @Inject()(
         .fetchAllArrivals(request.eoriNumber, request.channel)
         .map {
           allArrivals =>
-            Ok(Json.toJsObject(ResponseArrivals(allArrivals.map {
-              arrival =>
-                ResponseArrival.build(arrival)
-            })))
+            Ok(Json.toJsObject(ResponseArrivals(allArrivals)))
         }
         .recover {
           case e =>

--- a/app/metrics/Monitors.scala
+++ b/app/metrics/Monitors.scala
@@ -21,6 +21,7 @@ import models.Arrival
 import models.ChannelType
 import models.MessageType
 import models.SubmissionProcessingResult
+import models.response.ResponseArrival
 import play.api.libs.ws.WSResponse
 
 trait RequestMonitor[A] {
@@ -47,13 +48,13 @@ case class WSResponseMonitor(name: String) extends RequestMonitor[WSResponse] {
 case class DefaultRequestMonitor[A](name: String) extends RequestMonitor[A]
 
 object Monitors {
-  val UnloadingPermissionMonitor: WSResponseMonitor                  = WSResponseMonitor("get-unloading-permission")
-  val PostToEisMonitor: EisRequestMonitor                            = EisRequestMonitor("post-message-to-eis")
-  val GetArrivalsForEoriMonitor: DefaultRequestMonitor[Seq[Arrival]] = DefaultRequestMonitor[Seq[Arrival]]("get-arrivals-for-eori")
-  val GetArrivalByIdMonitor: DefaultRequestMonitor[Option[Arrival]]  = DefaultRequestMonitor[Option[Arrival]]("get-arrival-by-arrival-id")
-  val GetArrivalByMrnMonitor: DefaultRequestMonitor[Option[Arrival]] = DefaultRequestMonitor[Option[Arrival]]("get-arrival-by-mrn")
+  val UnloadingPermissionMonitor: WSResponseMonitor                          = WSResponseMonitor("get-unloading-permission")
+  val PostToEisMonitor: EisRequestMonitor                                    = EisRequestMonitor("post-message-to-eis")
+  val GetArrivalsForEoriMonitor: DefaultRequestMonitor[Seq[ResponseArrival]] = DefaultRequestMonitor[Seq[ResponseArrival]]("get-arrivals-for-eori")
+  val GetArrivalByIdMonitor: DefaultRequestMonitor[Option[Arrival]]          = DefaultRequestMonitor[Option[Arrival]]("get-arrival-by-arrival-id")
+  val GetArrivalByMrnMonitor: DefaultRequestMonitor[Option[Arrival]]         = DefaultRequestMonitor[Option[Arrival]]("get-arrival-by-mrn")
 
-  def arrivalsPerEori(arrivals: Seq[Arrival]): Counter =
+  def arrivalsPerEori(arrivals: Seq[ResponseArrival]): Counter =
     arrivals.size match {
       case s if s == 0   => Counter("arrivals-per-eori-0")
       case s if s <= 10  => Counter("arrivals-per-eori-1-10")

--- a/app/models/response/ResponseArrival.scala
+++ b/app/models/response/ResponseArrival.scala
@@ -17,14 +17,18 @@
 package models.response
 
 import java.time.LocalDateTime
-
 import controllers.routes
 import models.Arrival
 import models.ArrivalId
 import models.ArrivalStatus
+import models.MongoDateTimeFormats
 import models.MovementReferenceNumber
+import play.api.libs.json.JsObject
+import play.api.libs.json.JsResult
+import play.api.libs.json.JsValue
 import play.api.libs.json.Json
 import play.api.libs.json.OWrites
+import play.api.libs.json.Reads
 
 case class ResponseArrival(arrivalId: ArrivalId,
                            location: String,
@@ -34,7 +38,7 @@ case class ResponseArrival(arrivalId: ArrivalId,
                            created: LocalDateTime,
                            updated: LocalDateTime)
 
-object ResponseArrival {
+object ResponseArrival extends MongoDateTimeFormats {
 
   def build(arrival: Arrival): ResponseArrival =
     ResponseArrival(
@@ -46,6 +50,35 @@ object ResponseArrival {
       arrival.created,
       updated = arrival.lastUpdated
     )
+
+  val projection: JsObject = Json.obj(
+    "_id"                     -> 1,
+    "movementReferenceNumber" -> 1,
+    "status"                  -> 1,
+    "created"                 -> 1,
+    "lastUpdated"             -> 1
+  )
+
+  implicit def reads: Reads[ResponseArrival] =
+    json =>
+      for {
+        arrivalId <- (json \ "_id").validate[ArrivalId]
+        location         = routes.MovementsController.getArrival(arrivalId).url
+        messagesLocation = routes.MessagesController.getMessages(arrivalId).url
+        movementReferenceNumber <- (json \ "movementReferenceNumber").validate[MovementReferenceNumber]
+        status                  <- (json \ "status").validate[ArrivalStatus]
+        created                 <- (json \ "created").validate[LocalDateTime]
+        updated                 <- (json \ "lastUpdated").validate[LocalDateTime]
+      } yield
+        ResponseArrival(
+          arrivalId,
+          location,
+          messagesLocation,
+          movementReferenceNumber,
+          status,
+          created,
+          updated
+      )
 
   implicit val writes: OWrites[ResponseArrival] = Json.writes[ResponseArrival]
 

--- a/app/repositories/ArrivalMovementRepository.scala
+++ b/app/repositories/ArrivalMovementRepository.scala
@@ -17,7 +17,6 @@
 package repositories
 
 import java.time.LocalDateTime
-
 import com.google.inject.Inject
 import config.AppConfig
 import metrics.MetricsService
@@ -37,6 +36,7 @@ import models.MessageStatusUpdate
 import models.MongoDateTimeFormats
 import models.MovementMessage
 import models.MovementReferenceNumber
+import models.response.ResponseArrival
 import play.api.libs.json.JsObject
 import play.api.libs.json.Json
 import play.modules.reactivemongo.ReactiveMongoApi
@@ -143,11 +143,11 @@ class ArrivalMovementRepository @Inject()(mongo: ReactiveMongoApi, appConfig: Ap
     }
   }
 
-  def fetchAllArrivals(eoriNumber: String, channelFilter: ChannelType): Future[Seq[Arrival]] =
+  def fetchAllArrivals(eoriNumber: String, channelFilter: ChannelType): Future[Seq[ResponseArrival]] =
     metricsService.timeAsyncCall(Monitors.GetArrivalsForEoriMonitor) {
       collection.flatMap {
-        _.find(Json.obj("eoriNumber" -> eoriNumber, "channel" -> channelFilter), Option.empty[JsObject])
-          .cursor[Arrival]()
+        _.find(Json.obj("eoriNumber" -> eoriNumber, "channel" -> channelFilter), Some(ResponseArrival.projection))
+          .cursor[ResponseArrival]()
           .collect[Seq](-1, Cursor.FailOnError())
           .map {
             arrivals =>

--- a/it/repositories/ArrivalMovementRepositorySpec.scala
+++ b/it/repositories/ArrivalMovementRepositorySpec.scala
@@ -19,8 +19,8 @@ package repositories
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
-
 import base._
+import controllers.routes
 import models.ArrivalStatus.ArrivalSubmitted
 import models.ArrivalStatus.GoodsReleased
 import models.ArrivalStatus.Initialized
@@ -32,13 +32,15 @@ import models.ArrivalId
 import models.ArrivalIdSelector
 import models.ArrivalStatus
 import models.ArrivalStatusUpdate
-import models.ChannelType.{api, web}
+import models.ChannelType.api
+import models.ChannelType.web
 import models.MessageId
 import models.MessageType
 import models.MongoDateTimeFormats
 import models.MovementMessageWithStatus
 import models.MovementMessageWithoutStatus
 import models.MovementReferenceNumber
+import models.response.ResponseArrival
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalactic.source
 import org.scalatest.exceptions.StackDepthException
@@ -520,8 +522,8 @@ class ArrivalMovementRepositorySpec extends ItSpecBase with FailOnUnindexedQueri
 
           val movementReferenceNumber = arbitrary[MovementReferenceNumber].sample.value
 
-          val eori      = "eori"
-          val arrival   = arbitrary[Arrival].sample.value copy (eoriNumber = eori, movementReferenceNumber = movementReferenceNumber, channel = api)
+          val eori    = "eori"
+          val arrival = arbitrary[Arrival].sample.value copy (eoriNumber = eori, movementReferenceNumber = movementReferenceNumber, channel = api)
 
           repository.insert(arrival).futureValue
 
@@ -558,7 +560,7 @@ class ArrivalMovementRepositorySpec extends ItSpecBase with FailOnUnindexedQueri
     }
 
     "fetchAllArrivals" - {
-      "must return Arrival Movements that match an eoriNumber and channel type" in {
+      "must return Arrival Movements details that match an eoriNumber and channel type" in {
         database.flatMap(_.drop()).futureValue
 
         val app: Application = builder.build()
@@ -570,7 +572,7 @@ class ArrivalMovementRepositorySpec extends ItSpecBase with FailOnUnindexedQueri
         running(app) {
           started(app).futureValue
 
-          val service: ArrivalMovementRepository = app.injector.instanceOf[ArrivalMovementRepository]
+          val repository: ArrivalMovementRepository = app.injector.instanceOf[ArrivalMovementRepository]
 
           val allMovements = Seq(arrivalMovement1, arrivalMovement2, arrivalMovement3)
 
@@ -581,8 +583,28 @@ class ArrivalMovementRepositorySpec extends ItSpecBase with FailOnUnindexedQueri
               db.collection[JSONCollection](ArrivalMovementRepository.collectionName).insert(false).many(jsonArr)
           }.futureValue
 
-          service.fetchAllArrivals(eoriNumber, api).futureValue mustBe Seq(arrivalMovement1)
-          service.fetchAllArrivals(eoriNumber, web).futureValue mustBe Seq(arrivalMovement3)
+          val expectedApiFetchAll1 = ResponseArrival(
+            arrivalMovement1.arrivalId,
+            routes.MovementsController.getArrival(arrivalMovement1.arrivalId).url,
+            routes.MessagesController.getMessages(arrivalMovement1.arrivalId).url,
+            arrivalMovement1.movementReferenceNumber,
+            arrivalMovement1.status,
+            arrivalMovement1.created,
+            arrivalMovement1.lastUpdated
+          )
+
+          val expectedApiFetchAll3 = ResponseArrival(
+            arrivalMovement3.arrivalId,
+            routes.MovementsController.getArrival(arrivalMovement3.arrivalId).url,
+            routes.MessagesController.getMessages(arrivalMovement3.arrivalId).url,
+            arrivalMovement3.movementReferenceNumber,
+            arrivalMovement3.status,
+            arrivalMovement3.created,
+            arrivalMovement3.lastUpdated
+          )
+
+          repository.fetchAllArrivals(eoriNumber, api).futureValue mustBe Seq(expectedApiFetchAll1)
+          repository.fetchAllArrivals(eoriNumber, web).futureValue mustBe Seq(expectedApiFetchAll3)
         }
       }
 

--- a/test/controllers/MovementsControllerSpec.scala
+++ b/test/controllers/MovementsControllerSpec.scala
@@ -990,7 +990,7 @@ class MovementsControllerSpec extends SpecBase with ScalaCheckPropertyChecks wit
             .build()
 
         running(application) {
-          forAll(listWithMaxLength[Arrival](10)) {
+          forAll(listWithMaxLength[ResponseArrival](10)) {
             arrivals =>
               when(mockArrivalMovementRepository.fetchAllArrivals(any(), any())).thenReturn(Future.successful(arrivals))
 
@@ -999,10 +999,7 @@ class MovementsControllerSpec extends SpecBase with ScalaCheckPropertyChecks wit
               val result = route(application, request).value
 
               status(result) mustEqual OK
-              contentAsJson(result) mustEqual Json.toJson(ResponseArrivals(arrivals.map {
-                a =>
-                  ResponseArrival.build(a)
-              }))
+              contentAsJson(result) mustEqual Json.toJson(ResponseArrivals(arrivals))
 
               reset(mockArrivalMovementRepository)
           }

--- a/test/generators/ModelGenerators.scala
+++ b/test/generators/ModelGenerators.scala
@@ -17,7 +17,6 @@
 package generators
 
 import java.time._
-
 import cats.data.NonEmptyList
 import connectors.MessageConnector.EisSubmissionResult
 import connectors.MessageConnector.EisSubmissionResult.DownstreamBadGateway
@@ -47,6 +46,7 @@ import models.MovementMessageWithoutStatus
 import models.MovementReferenceNumber
 import models.RejectionError
 import models.SubmissionProcessingResult
+import models.response.ResponseArrival
 import models.response.ResponseMovementMessage
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Arbitrary
@@ -167,7 +167,7 @@ trait ModelGenerators extends BaseGenerators with JavaTimeGenerators {
           status = status,
           created = created,
           updated = updated,
-          lastUpdated = LocalDateTime.now,
+          lastUpdated = updated,
           messages = messages,
           nextMessageCorrelationId = messages.length + 1
         )
@@ -266,5 +266,18 @@ trait ModelGenerators extends BaseGenerators with JavaTimeGenerators {
         arbitrary[EisSubmissionFailureDownstream],
         Gen.const(EisSubmissionSuccessful)
       )
+    )
+
+  implicit val arbitraryResponseArrival: Arbitrary[ResponseArrival] =
+    Arbitrary(
+      for {
+        arrivalId               <- arbitrary[ArrivalId]
+        location                <- arbitrary[String]
+        messagesLocation        <- arbitrary[String]
+        movementReferenceNumber <- arbitrary[MovementReferenceNumber]
+        status                  <- arbitrary[ArrivalStatus]
+        created                 <- arbitrary[LocalDateTime]
+        updated                 <- arbitrary[LocalDateTime]
+      } yield ResponseArrival(arrivalId, location, messagesLocation, movementReferenceNumber, status, created, updated)
     )
 }


### PR DESCRIPTION
This doesn't change the inteface of the service but is to reduce the pressure on the garbage collector for the large seq of json objects that are loaded from mongo.
