### PR TITLE
Improve logging of movement summaries

### DIFF
--- a/app/models/Arrival.scala
+++ b/app/models/Arrival.scala
@@ -42,7 +42,7 @@ case class Arrival(
   lazy val messagesWithId: NonEmptyList[(MovementMessage, MessageId)] =
     messages.mapWithIndex(_ -> MessageId.fromIndex(_))
 
-  private val obfuscatedEori: String          = s"ending ${eoriNumber.takeRight(4)}"
+  private val obfuscatedEori: String          = s"ending ${eoriNumber.takeRight(7)}"
   private val isoFormatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
 
   val summaryInformation: Map[String, String] = Map(


### PR DESCRIPTION
The final three digits of an EORI number are (almost) always either
000 or 001, so logging slightly more digits gives us more
meaningful information for suport.