### PR TITLE
CTDA-1308 Filter arrival messages by last updated timestamp

### DIFF
--- a/app/connectors/MessageConnector.scala
+++ b/app/connectors/MessageConnector.scala
@@ -33,7 +33,7 @@ import models.TransitWrapper
 import uk.gov.hmrc.http.HttpReads.Implicits.readRaw
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.HttpResponse
-import uk.gov.hmrc.play.bootstrap.http.HttpClient
+import uk.gov.hmrc.http.HttpClient
 import utils.Format
 
 import scala.concurrent.ExecutionContext

--- a/app/controllers/MessagesController.scala
+++ b/app/controllers/MessagesController.scala
@@ -40,7 +40,7 @@ import play.api.mvc.AnyContent
 import play.api.mvc.ControllerComponents
 import services.ArrivalMovementMessageService
 import services.SubmitMessageService
-import uk.gov.hmrc.play.bootstrap.controller.BackendController
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext

--- a/app/controllers/MessagesSummaryController.scala
+++ b/app/controllers/MessagesSummaryController.scala
@@ -26,7 +26,7 @@ import play.api.mvc.Action
 import play.api.mvc.AnyContent
 import play.api.mvc.ControllerComponents
 import services.ArrivalMessageSummaryService
-import uk.gov.hmrc.play.bootstrap.controller.BackendController
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import scala.concurrent.ExecutionContext
 

--- a/app/controllers/MovementsController.scala
+++ b/app/controllers/MovementsController.scala
@@ -17,6 +17,7 @@
 package controllers
 
 import javax.inject.Inject
+import java.time.OffsetDateTime
 
 import audit.AuditService
 import audit.AuditType
@@ -46,7 +47,7 @@ import repositories.ArrivalMovementRepository
 import services.ArrivalMovementMessageService
 import services.SubmitMessageService
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.bootstrap.controller.BackendController
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -182,12 +183,12 @@ class MovementsController @Inject()(
       }
     }
 
-  def getArrivals(): Action[AnyContent] =
+  def getArrivals(updatedSince: Option[OffsetDateTime]): Action[AnyContent] =
     withMetricsTimerAction("get-all-arrivals") {
       authenticate().async {
         implicit request =>
           arrivalMovementRepository
-            .fetchAllArrivals(request.eoriNumber, request.channel)
+            .fetchAllArrivals(request.eoriNumber, request.channel, updatedSince)
             .map {
               allArrivals =>
                 countArrivals.update(allArrivals.length)

--- a/app/controllers/NCTSMessageController.scala
+++ b/app/controllers/NCTSMessageController.scala
@@ -31,7 +31,7 @@ import play.api.mvc.Action
 import play.api.mvc.ControllerComponents
 import play.api.mvc.Result
 import services.SaveMessageService
-import uk.gov.hmrc.play.bootstrap.controller.BackendController
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext

--- a/app/models/ArrivalUpdate.scala
+++ b/app/models/ArrivalUpdate.scala
@@ -68,7 +68,7 @@ object MessageStatusUpdate extends MongoDateTimeFormats {
           "$set" ->
             Json.obj(
               s"messages.${value.messageId.index}.status" -> value.messageStatus,
-              "lastUpdated"                               -> LocalDateTime.now(clock).withSecond(0).withNano(0)
+              "lastUpdated"                               -> LocalDateTime.now(clock)
             )
       )
     )
@@ -83,7 +83,7 @@ object ArrivalStatusUpdate extends MongoDateTimeFormats {
       Json.obj(
         "$set" -> Json.obj(
           "status"      -> value.arrivalStatus,
-          "lastUpdated" -> LocalDateTime.now(clock).withSecond(0).withNano(0)
+          "lastUpdated" -> LocalDateTime.now(clock)
         )
     )
 }
@@ -105,7 +105,7 @@ object ArrivalPutUpdate extends MongoDateTimeFormats {
       Json.obj(
         "$set" -> Json.obj(
           "movementReferenceNumber" -> a.movementReferenceNumber,
-          "lastUpdated"             -> LocalDateTime.now(clock).withSecond(0).withNano(0)
+          "lastUpdated"             -> LocalDateTime.now(clock)
         )
       ) deepMerge ArrivalModifier.toJson(a.arrivalUpdate)
 

--- a/app/models/Binders.scala
+++ b/app/models/Binders.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import play.api.mvc.QueryStringBindable
+
+object Binders {
+  implicit val offsetDateTimeQueryStringBindable: QueryStringBindable[OffsetDateTime] = {
+    new QueryStringBindable.Parsing[OffsetDateTime](
+      OffsetDateTime.parse(_),
+      dt => DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(dt),
+      (param, exc) => s"Cannot parse parameter $param as OffsetDateTime: ${exc.getMessage}"
+    )
+  }
+}

--- a/app/models/MongoDateTimeFormats.scala
+++ b/app/models/MongoDateTimeFormats.scala
@@ -25,6 +25,7 @@ import play.api.libs.json.Json
 import play.api.libs.json.Reads
 import play.api.libs.json.Writes
 import play.api.libs.json.__
+import java.time.OffsetDateTime
 
 trait MongoDateTimeFormats {
 
@@ -40,6 +41,12 @@ trait MongoDateTimeFormats {
       "$date" -> dateTime.atZone(ZoneOffset.UTC).toInstant.toEpochMilli
     )
   }
+
+  implicit val offsetDateTimeRead: Reads[OffsetDateTime] =
+    localDateTimeRead.map(_.atOffset(ZoneOffset.UTC))
+
+  implicit val offsetDateTimeWrite: Writes[OffsetDateTime] =
+    localDateTimeWrite.contramap(_.atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime)
 }
 
 object MongoDateTimeFormats extends MongoDateTimeFormats

--- a/app/repositories/ArrivalMovementRepository.scala
+++ b/app/repositories/ArrivalMovementRepository.scala
@@ -58,6 +58,7 @@ import utils.IndexUtils
 
 import java.time.Clock
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -112,21 +113,21 @@ class ArrivalMovementRepository @Inject()(
           true
       }
   }
-  private val eoriNumberIndex: Aux[BSONSerializationPack.type] = IndexUtils.index(
+  private lazy val eoriNumberIndex: Aux[BSONSerializationPack.type] = IndexUtils.index(
     key = Seq("eoriNumber" -> IndexType.Ascending),
     name = Some("eori-number-index")
   )
-  private val movementReferenceNumber: Aux[BSONSerializationPack.type] = IndexUtils.index(
+  private lazy val movementReferenceNumber: Aux[BSONSerializationPack.type] = IndexUtils.index(
     key = Seq("movementReferenceNumber" -> IndexType.Ascending),
     name = Some("movement-reference-number-index")
   )
-  private val lastUpdatedIndex: Aux[BSONSerializationPack.type] = IndexUtils.index(
+  private lazy val lastUpdatedIndex: Aux[BSONSerializationPack.type] = IndexUtils.index(
     key = Seq("lastUpdated" -> IndexType.Ascending),
     name = Some("last-updated-index"),
     options = BSONDocument("expireAfterSeconds" -> appConfig.cacheTtl)
   )
-  private val oldLastUpdatedIndexName = "last-updated-index-6m"
-  private val collectionName          = ArrivalMovementRepository.collectionName
+  private lazy val oldLastUpdatedIndexName = "last-updated-index-6m"
+  private lazy val collectionName          = ArrivalMovementRepository.collectionName
 
   def insert(arrival: Arrival): Future[Unit] =
     collection.flatMap {
@@ -182,11 +183,14 @@ class ArrivalMovementRepository @Inject()(
     }
   }
 
-  def fetchAllArrivals(eoriNumber: String, channelFilter: ChannelType): Future[Seq[ResponseArrival]] =
+  def fetchAllArrivals(eoriNumber: String, channelFilter: ChannelType, updatedSince: Option[OffsetDateTime]): Future[Seq[ResponseArrival]] =
     withMetricsTimerAsync("mongo-get-arrivals-for-eori") {
       _ =>
+        val dateFilter = updatedSince.map(dateTime => Json.obj("lastUpdated" -> Json.obj("$gte" -> dateTime))).getOrElse(Json.obj())
+        val selector   = Json.obj("eoriNumber" -> eoriNumber, "channel" -> channelFilter) ++ dateFilter
+
         collection.flatMap {
-          _.find(Json.obj("eoriNumber" -> eoriNumber, "channel" -> channelFilter), Some(ResponseArrival.projection))
+          _.find(selector, Some(ResponseArrival.projection))
             .cursor[ResponseArrival]()
             .collect[Seq](-1, Cursor.FailOnError())
             .map {
@@ -202,6 +206,7 @@ class ArrivalMovementRepository @Inject()(
                                      messageId: MessageId,
                                      arrivalState: ArrivalStatus,
                                      messageState: MessageStatus): Future[Option[Unit]] = {
+    implicit val modifierClock: Clock = clock
 
     val selector = ArrivalIdSelector(arrivalId)
 

--- a/app/services/SubmitMessageService.scala
+++ b/app/services/SubmitMessageService.scala
@@ -16,6 +16,7 @@
 
 package services
 
+import java.time.Clock
 import java.time.OffsetDateTime
 
 import cats.implicits._
@@ -53,7 +54,7 @@ import scala.util.Success
 class SubmitMessageService @Inject()(
   arrivalMovementRepository: ArrivalMovementRepository,
   messageConnector: MessageConnector,
-)(implicit ec: ExecutionContext)
+)(implicit clock: Clock, ec: ExecutionContext)
     extends Logging {
 
   def submitMessage(arrivalId: ArrivalId, messageId: MessageId, message: MovementMessageWithStatus, arrivalStatus: ArrivalStatus, channelType: ChannelType)(

--- a/app/testOnly/controllers/TestOnlyController.scala
+++ b/app/testOnly/controllers/TestOnlyController.scala
@@ -24,7 +24,7 @@ import play.api.mvc.ControllerComponents
 import play.modules.reactivemongo.ReactiveMongoApi
 import reactivemongo.play.json.collection.JSONCollection
 import repositories.ArrivalMovementRepository
-import uk.gov.hmrc.play.bootstrap.controller.BackendController
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext

--- a/app/testOnly/controllers/TestOnlySeedDataController.scala
+++ b/app/testOnly/controllers/TestOnlySeedDataController.scala
@@ -26,7 +26,7 @@ import repositories.ArrivalMovementRepository
 import testOnly.models.SeedDataParameters
 import testOnly.models.SeedDataResponse
 import testOnly.services.TestOnlySeedDataService
-import uk.gov.hmrc.play.bootstrap.controller.BackendController
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import java.time.Clock
 import javax.inject.Inject

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,7 +1,7 @@
 # microservice specific routes
 
 POST    /movements/arrivals                                     controllers.MovementsController.post
-GET     /movements/arrivals                                     controllers.MovementsController.getArrivals(updated_since: Option[OffsetDateTime] ?= None)
+GET     /movements/arrivals                                     controllers.MovementsController.getArrivals(updatedSince: Option[OffsetDateTime] ?= None)
 
 GET     /movements/arrivals/:arrivalId                          controllers.MovementsController.getArrival(arrivalId: ArrivalId)
 PUT     /movements/arrivals/:arrivalId                          controllers.MovementsController.putArrival(arrivalId: ArrivalId)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,7 +1,7 @@
 # microservice specific routes
 
 POST    /movements/arrivals                                     controllers.MovementsController.post
-GET     /movements/arrivals                                     controllers.MovementsController.getArrivals()
+GET     /movements/arrivals                                     controllers.MovementsController.getArrivals(updated_since: Option[OffsetDateTime] ?= None)
 
 GET     /movements/arrivals/:arrivalId                          controllers.MovementsController.getArrival(arrivalId: ArrivalId)
 PUT     /movements/arrivals/:arrivalId                          controllers.MovementsController.putArrival(arrivalId: ArrivalId)

--- a/it/api/OutboundMessagesApiSpec.scala
+++ b/it/api/OutboundMessagesApiSpec.scala
@@ -126,7 +126,7 @@ class OutboundMessagesApiSpec
   }
 
   "getArrivals" - {
-    "accepts updated_since parameter in valid date format" in {
+    "accepts updatedSince parameter in valid date format" in {
       import models.ChannelType._
 
       val eoriNumber: String = arbitrary[String].sample.value
@@ -152,7 +152,7 @@ class OutboundMessagesApiSpec
 
       val response = await(
         ws
-          .url(s"http://localhost:$port/transit-movements-trader-at-destination/movements/arrivals?updated_since=${encodedStr}")
+          .url(s"http://localhost:$port/transit-movements-trader-at-destination/movements/arrivals?updatedSince=${encodedStr}")
           .withHttpHeaders(
             "Channel"      -> api.toString,
             "Content-Type" -> "application/xml"
@@ -165,7 +165,7 @@ class OutboundMessagesApiSpec
       (response.json \\ "arrivalId").toSet mustBe Set(JsNumber(arrivalMovement2.arrivalId.index), JsNumber(arrivalMovement4.arrivalId.index))
     }
 
-    "does not require updated_since parameter" in {
+    "does not require updatedSince parameter" in {
       import models.ChannelType._
 
       val eoriNumber: String = arbitrary[String].sample.value
@@ -187,7 +187,7 @@ class OutboundMessagesApiSpec
       response.status mustBe OK
     }
 
-    "rejects updated_since parameter in invalid date format" in {
+    "rejects updatedSince parameter in invalid date format" in {
       import models.ChannelType._
 
       val eoriNumber: String = arbitrary[String].sample.value
@@ -202,7 +202,7 @@ class OutboundMessagesApiSpec
 
       val response = await(
         ws
-          .url(s"http://localhost:$port/transit-movements-trader-at-destination/movements/arrivals?updated_since=${encodedStr}")
+          .url(s"http://localhost:$port/transit-movements-trader-at-destination/movements/arrivals?updatedSince=${encodedStr}")
           .withHttpHeaders(
             "Channel"      -> api.toString,
             "Content-Type" -> "application/xml"

--- a/it/api/OutboundMessagesApiSpec.scala
+++ b/it/api/OutboundMessagesApiSpec.scala
@@ -16,48 +16,64 @@
 
 package api
 
+import cats.syntax.all._
 import cats.data.NonEmptyList
 
-import play.api.test.Helpers.ACCEPTED
-import play.api.test.Helpers.BAD_REQUEST
+import play.api.test.Helpers._
 import generators.ModelGenerators
 import models.ArrivalStatus.UnloadingPermission
-import models.{Arrival, MessageStatus, MessageType, MovementMessageWithStatus, MovementMessageWithoutStatus}
+import models.Arrival
+import models.MessageStatus
+import models.MessageType
+import models.MovementMessageWithStatus
+import models.MovementMessageWithoutStatus
 import org.scalacheck.Arbitrary.arbitrary
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import org.scalatest.{EitherValues, OptionValues}
+import org.scalatest.EitherValues
+import org.scalatest.OptionValues
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.Application
-import play.api.libs.json.Json
+import play.api.libs.json.JsNumber
 import play.api.libs.ws.WSClient
-import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
+import play.api.test.DefaultAwaitTimeout
+import play.api.test.FutureAwaits
 import repositories.ArrivalMovementRepository
 import utils.Format
 
+import java.net.URLEncoder
+import java.time.ZoneOffset
+import java.time.OffsetDateTime
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
-class OutboundMessagesApiSpec extends AnyFreeSpec with GuiceOneServerPerSuite with Matchers
-  with ScalaCheckPropertyChecks
-  with ModelGenerators
-  with OptionValues
-  with EitherValues
-  with FutureAwaits
-  with DefaultAwaitTimeout
-  with ScalaFutures
-  with WiremockSuite
-{
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class OutboundMessagesApiSpec
+    extends AnyFreeSpec
+    with GuiceOneServerPerSuite
+    with Matchers
+    with ScalaCheckPropertyChecks
+    with ModelGenerators
+    with OptionValues
+    with EitherValues
+    with FutureAwaits
+    with DefaultAwaitTimeout
+    with ScalaFutures
+    with WiremockSuite
+    with BeforeAndAfterEach {
 
   override protected def portConfigKeys: Seq[String] = Seq(
     "microservice.services.auth.port",
     "microservice.services.eis.port"
   )
 
-  override implicit lazy val app: Application = appBuilder.build()
+  implicit override lazy val app: Application = appBuilder.build()
 
-  lazy val ws: WSClient = app.injector.instanceOf[WSClient]
+  lazy val ws: WSClient                    = app.injector.instanceOf[WSClient]
   lazy val repo: ArrivalMovementRepository = app.injector.instanceOf[ArrivalMovementRepository]
 
   "postMessage" - {
@@ -68,7 +84,8 @@ class OutboundMessagesApiSpec extends AnyFreeSpec with GuiceOneServerPerSuite wi
         MovementMessageWithoutStatus(LocalDateTime.now(), MessageType.UnloadingPermission, <CC043A></CC043A>, 1) :: Nil
       )
 
-      val arrival = arbitrary[Arrival].sample.value.copy(messages = movements, status = UnloadingPermission)
+      val arrival =
+        arbitrary[Arrival].sample.value.copy(messages = movements, status = UnloadingPermission, lastUpdated = LocalDateTime.of(1998, 4, 30, 9, 30, 31))
 
       val requestBody = <CC044A>
         <DatOfPreMES9>{Format.dateFormatted(LocalDateTime.now())}</DatOfPreMES9>
@@ -79,30 +96,122 @@ class OutboundMessagesApiSpec extends AnyFreeSpec with GuiceOneServerPerSuite wi
         </HEAHEA>
       </CC044A>
 
-      repo.insert(arrival).futureValue
+      await(repo.insert(arrival))
 
       Stubs(server)
         .successfulAuth(arrival.eoriNumber)
         .successfulSubmission()
         .build()
 
-      await(ws
-        .url(s"http://localhost:$port/transit-movements-trader-at-destination/movements/arrivals/${arrival.arrivalId.index}/messages")
-        .withHttpHeaders(
-          "Channel" -> arrival.channel.toString,
-          "Content-Type" -> "application/xml"
-        )
-        .post(requestBody)).status mustBe ACCEPTED
+      await(
+        ws
+          .url(s"http://localhost:$port/transit-movements-trader-at-destination/movements/arrivals/${arrival.arrivalId.index}/messages")
+          .withHttpHeaders(
+            "Channel"      -> arrival.channel.toString,
+            "Content-Type" -> "application/xml"
+          )
+          .post(requestBody)
+      ).status mustBe ACCEPTED
 
-      await(ws
-        .url(s"http://localhost:$port/transit-movements-trader-at-destination/movements/arrivals/${arrival.arrivalId.index}/messages")
-        .withHttpHeaders(
-          "Channel" -> arrival.channel.toString,
-          "Content-Type" -> "application/xml"
-        )
-        .post(requestBody)).status mustBe BAD_REQUEST
+      await(
+        ws
+          .url(s"http://localhost:$port/transit-movements-trader-at-destination/movements/arrivals/${arrival.arrivalId.index}/messages")
+          .withHttpHeaders(
+            "Channel"      -> arrival.channel.toString,
+            "Content-Type" -> "application/xml"
+          )
+          .post(requestBody)
+      ).status mustBe BAD_REQUEST
     }
   }
 
+  "getArrivals" - {
+    "accepts updated_since parameter in valid date format" in {
+      import models.ChannelType._
+
+      val eoriNumber: String = arbitrary[String].sample.value
+
+      val arrivalMovement1 =
+        arbitrary[Arrival].sample.value.copy(eoriNumber = eoriNumber, channel = api, lastUpdated = LocalDateTime.of(2021, 4, 30, 9, 30, 31))
+      val arrivalMovement2 =
+        arbitrary[Arrival].sample.value.copy(eoriNumber = eoriNumber, channel = api, lastUpdated = LocalDateTime.of(2021, 4, 30, 9, 35, 32))
+      val arrivalMovement3 =
+        arbitrary[Arrival].sample.value.copy(eoriNumber = eoriNumber, channel = api, lastUpdated = LocalDateTime.of(2021, 4, 30, 9, 30, 21))
+      val arrivalMovement4 =
+        arbitrary[Arrival].sample.value.copy(eoriNumber = eoriNumber, channel = api, lastUpdated = LocalDateTime.of(2021, 4, 30, 10, 15, 16))
+
+      await(List(arrivalMovement1, arrivalMovement2, arrivalMovement3, arrivalMovement4).traverse(repo.insert))
+
+      Stubs(server)
+        .successfulAuth(eoriNumber)
+        .build
+
+      val dateTime = OffsetDateTime.of(LocalDateTime.of(2021, 4, 30, 10, 30, 32), ZoneOffset.ofHours(1))
+      val dateTimeStr = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(dateTime)
+      val encodedStr = URLEncoder.encode(dateTimeStr, "UTF-8")
+
+      val response = await(
+        ws
+          .url(s"http://localhost:$port/transit-movements-trader-at-destination/movements/arrivals?updated_since=${encodedStr}")
+          .withHttpHeaders(
+            "Channel"      -> api.toString,
+            "Content-Type" -> "application/xml"
+          )
+          .get()
+      )
+
+      response.status mustBe OK
+
+      (response.json \\ "arrivalId").toSet mustBe Set(JsNumber(arrivalMovement2.arrivalId.index), JsNumber(arrivalMovement4.arrivalId.index))
+    }
+
+    "does not require updated_since parameter" in {
+      import models.ChannelType._
+
+      val eoriNumber: String = arbitrary[String].sample.value
+
+      Stubs(server)
+        .successfulAuth(eoriNumber)
+        .build
+
+      val response = await(
+        ws
+          .url(s"http://localhost:$port/transit-movements-trader-at-destination/movements/arrivals")
+          .withHttpHeaders(
+            "Channel"      -> api.toString,
+            "Content-Type" -> "application/xml"
+          )
+          .get()
+      )
+
+      response.status mustBe OK
+    }
+
+    "rejects updated_since parameter in invalid date format" in {
+      import models.ChannelType._
+
+      val eoriNumber: String = arbitrary[String].sample.value
+
+      Stubs(server)
+        .successfulAuth(eoriNumber)
+        .build
+
+      val dateTime = OffsetDateTime.of(LocalDateTime.of(2021, 4, 30, 10, 30, 32), ZoneOffset.ofHours(1))
+      val dateTimeStr = DateTimeFormatter.RFC_1123_DATE_TIME.format(dateTime)
+      val encodedStr = URLEncoder.encode(dateTimeStr, "UTF-8")
+
+      val response = await(
+        ws
+          .url(s"http://localhost:$port/transit-movements-trader-at-destination/movements/arrivals?updated_since=${encodedStr}")
+          .withHttpHeaders(
+            "Channel"      -> api.toString,
+            "Content-Type" -> "application/xml"
+          )
+          .get()
+      )
+
+      response.status mustBe BAD_REQUEST
+    }
+  }
 
 }

--- a/it/repositories/ArrivalMovementRepositorySpec.scala
+++ b/it/repositories/ArrivalMovementRepositorySpec.scala
@@ -57,7 +57,7 @@ class ArrivalMovementRepositorySpec
     with BeforeAndAfterEach {
 
   private val instant = Instant.now
-  private val stubClock: Clock = Clock.fixed(instant, ZoneId.systemDefault)
+  implicit private val stubClock: Clock = Clock.fixed(instant, ZoneId.systemDefault)
   private val appBuilder: GuiceApplicationBuilder =
     new GuiceApplicationBuilder()
       .overrides(bind[Clock].toInstance(stubClock))
@@ -551,8 +551,8 @@ class ArrivalMovementRepositorySpec
             arrivalMovement3.lastUpdated
           )
 
-          repository.fetchAllArrivals(eoriNumber, api).futureValue mustBe Seq(expectedApiFetchAll1)
-          repository.fetchAllArrivals(eoriNumber, web).futureValue mustBe Seq(expectedApiFetchAll3)
+          repository.fetchAllArrivals(eoriNumber, api, None).futureValue mustBe Seq(expectedApiFetchAll1)
+          repository.fetchAllArrivals(eoriNumber, web, None).futureValue mustBe Seq(expectedApiFetchAll3)
         }
       }
 
@@ -575,9 +575,38 @@ class ArrivalMovementRepositorySpec
               db.collection[JSONCollection](ArrivalMovementRepository.collectionName).insert(false).many(jsonArr)
           }.futureValue
 
-          val result = service.fetchAllArrivals(eoriNumber, api).futureValue
+          val result = service.fetchAllArrivals(eoriNumber, api, None).futureValue
 
           result mustBe Seq.empty[Arrival]
+        }
+      }
+
+      "must filter results by lastUpdated when updatedSince parameter is provided" in {
+
+        val arrivalMovement1 = arbitrary[Arrival].sample.value.copy(eoriNumber = eoriNumber, channel = api, lastUpdated = LocalDateTime.of(2021, 4, 30, 9, 30, 31))
+        val arrivalMovement2 = arbitrary[Arrival].sample.value.copy(eoriNumber = eoriNumber, channel = api, lastUpdated = LocalDateTime.of(2021, 4, 30, 9, 35, 32))
+        val arrivalMovement3 = arbitrary[Arrival].sample.value.copy(eoriNumber = eoriNumber, channel = api, lastUpdated = LocalDateTime.of(2021, 4, 30, 9, 30, 21))
+        val arrivalMovement4 = arbitrary[Arrival].sample.value.copy(eoriNumber = eoriNumber, channel = api, lastUpdated = LocalDateTime.of(2021, 4, 30, 10, 15, 16))
+
+        val app = appBuilder.build()
+        running(app) {
+
+          val service: ArrivalMovementRepository = app.injector.instanceOf[ArrivalMovementRepository]
+
+          val allMovements = Seq(arrivalMovement1, arrivalMovement2, arrivalMovement3, arrivalMovement4)
+
+          val jsonArr = allMovements.map(Json.toJsObject(_))
+
+          database.flatMap {
+            db =>
+              db.collection[JSONCollection](ArrivalMovementRepository.collectionName).insert(false).many(jsonArr)
+          }.futureValue
+
+          val dateTime = OffsetDateTime.of(LocalDateTime.of(2021, 4, 30, 10, 30, 32), ZoneOffset.ofHours(1))
+          val actual = service.fetchAllArrivals(eoriNumber, api, Some(dateTime)).futureValue.toSet
+          val expected = Set(arrivalMovement2, arrivalMovement4).map(ResponseArrival.build)
+
+          actual mustEqual expected
         }
       }
     }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,11 +3,11 @@ import sbt._
 
 object AppDependencies {
 
-  private val catsVersion = "2.1.1"
+  private val catsVersion = "2.5.0"
 
   val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"       %% "bootstrap-backend-play-27"       % "3.3.0",
-    "org.reactivemongo" %% "play2-reactivemongo"             % "0.20.11-play26",
+    "uk.gov.hmrc"       %% "bootstrap-backend-play-27"       % "3.4.0",
+    "org.reactivemongo" %% "play2-reactivemongo"             % "0.20.11-play27",
     "org.reactivemongo" %% "reactivemongo-akkastream"        % "0.20.11",
     "com.typesafe.play" %% "play-iteratees"                  % "2.6.1",
     "com.typesafe.play" %% "play-iteratees-reactive-streams" % "2.6.1",
@@ -17,16 +17,16 @@ object AppDependencies {
 
   val test: Seq[ModuleID] = Seq(
     "org.mockito"            % "mockito-core"          % "3.3.3",
-    "org.scalatest"          %% "scalatest"            % "3.2.0",
+    "org.scalatest"          %% "scalatest"            % "3.2.8",
     "com.typesafe.play"      %% "play-test"            % current,
     "org.pegdown"            % "pegdown"               % "1.6.0",
     "org.scalatestplus.play" %% "scalatestplus-play"   % "4.0.3",
     "org.scalatestplus"      %% "mockito-3-2"          % "3.1.2.0",
     "org.scalacheck"         %% "scalacheck"           % "1.14.3",
-    "com.github.tomakehurst" % "wiremock-standalone"   % "2.27.1",
+    "com.github.tomakehurst" % "wiremock-standalone"   % "2.27.2",
     "org.typelevel"          %% "cats-laws"            % catsVersion,
-    "org.typelevel"          %% "discipline-core"      % "1.0.2",
-    "org.typelevel"          %% "discipline-scalatest" % "1.0.1",
+    "org.typelevel"          %% "discipline-core"      % "1.1.4",
+    "org.typelevel"          %% "discipline-scalatest" % "2.1.4",
     "com.vladsch.flexmark"   % "flexmark-all"          % "0.35.10",
     "com.typesafe.akka"      %% "akka-stream-testkit"  % "2.5.31"
   ).map(_ % "test, it")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,21 +1,21 @@
-resolvers += Resolver.url("HMRC Sbt Plugin Releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(
-  Resolver.ivyStylePatterns)
+resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
 
-resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
+resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-resolvers += Resolver.typesafeRepo("releases")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.15.0")
 
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.15.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.3.0")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.9")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.7.0")
 
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.16")
+
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.5.3")
+
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.17")

--- a/test/controllers/MovementsControllerSpec.scala
+++ b/test/controllers/MovementsControllerSpec.scala
@@ -998,7 +998,7 @@ class MovementsControllerSpec extends SpecBase with ScalaCheckPropertyChecks wit
         running(application) {
           forAll(listWithMaxLength[ResponseArrival](10)) {
             arrivals =>
-              when(mockArrivalMovementRepository.fetchAllArrivals(any(), any())).thenReturn(Future.successful(arrivals))
+              when(mockArrivalMovementRepository.fetchAllArrivals(any(), any(), any())).thenReturn(Future.successful(arrivals))
 
               val request = FakeRequest(GET, routes.MovementsController.getArrivals().url)
 
@@ -1035,7 +1035,7 @@ class MovementsControllerSpec extends SpecBase with ScalaCheckPropertyChecks wit
               createdAndUpdatedDate
             )
           )
-          when(mockArrivalMovementRepository.fetchAllArrivals(any(), any())).thenReturn(Future.successful(arrivals))
+          when(mockArrivalMovementRepository.fetchAllArrivals(any(), any(), any())).thenReturn(Future.successful(arrivals))
 
           val request = FakeRequest(GET, routes.MovementsController.getArrivals().url)
 
@@ -1066,7 +1066,7 @@ class MovementsControllerSpec extends SpecBase with ScalaCheckPropertyChecks wit
 
       "must return an INTERNAL_SERVER_ERROR when we cannot retrieve the Arrival Movements" in {
         val mockArrivalMovementRepository = mock[ArrivalMovementRepository]
-        when(mockArrivalMovementRepository.fetchAllArrivals(any(), any()))
+        when(mockArrivalMovementRepository.fetchAllArrivals(any(), any(), any()))
           .thenReturn(Future.failed(new Exception))
 
         val application =

--- a/test/models/ArrivalStatusSpec.scala
+++ b/test/models/ArrivalStatusSpec.scala
@@ -28,23 +28,23 @@ class ArrivalStatusSpec extends SpecBase with ScalaCheckDrivenPropertyChecks wit
     "Initialized must" - {
 
       "transition to ArrivalSubmitted when receiving a ArrivalSubmitted event" in {
-        Initialized.transition(MessageReceivedEvent.ArrivalSubmitted).right.value mustBe ArrivalSubmitted
+        Initialized.transition(MessageReceivedEvent.ArrivalSubmitted).value mustBe ArrivalSubmitted
       }
 
       "transition to Goods Released when receiving a GoodsReleased event" in {
-        Initialized.transition(MessageReceivedEvent.GoodsReleased).right.value mustBe GoodsReleased
+        Initialized.transition(MessageReceivedEvent.GoodsReleased).value mustBe GoodsReleased
       }
 
       "transition to Unloading Permsission when receiving a UnloadingPermission event" in {
-        Initialized.transition(MessageReceivedEvent.UnloadingPermission).right.value mustBe UnloadingPermission
+        Initialized.transition(MessageReceivedEvent.UnloadingPermission).value mustBe UnloadingPermission
       }
 
       "transition to Arrival Rejected when receiving a ArrivalRejected event" in {
-        Initialized.transition(MessageReceivedEvent.ArrivalRejected).right.value mustBe ArrivalRejected
+        Initialized.transition(MessageReceivedEvent.ArrivalRejected).value mustBe ArrivalRejected
       }
 
       "transition to Unloading remarks Rejected when receiving a UnloadingRemarksRejected event" in {
-        Initialized.transition(MessageReceivedEvent.UnloadingRemarksRejected).right.value mustBe UnloadingRemarksRejected
+        Initialized.transition(MessageReceivedEvent.UnloadingRemarksRejected).value mustBe UnloadingRemarksRejected
       }
 
       "return an error message if any other event is provided" in {
@@ -83,19 +83,19 @@ class ArrivalStatusSpec extends SpecBase with ScalaCheckDrivenPropertyChecks wit
       }
 
       "transition to GoodsReceived when receiving a GoodsReleased event" in {
-        ArrivalSubmitted.transition(MessageReceivedEvent.GoodsReleased).right.value mustBe GoodsReleased
+        ArrivalSubmitted.transition(MessageReceivedEvent.GoodsReleased).value mustBe GoodsReleased
       }
 
       "transition to Unloading Permission when receiving a UnloadingPermission event" in {
-        ArrivalSubmitted.transition(MessageReceivedEvent.UnloadingPermission).right.value mustBe UnloadingPermission
+        ArrivalSubmitted.transition(MessageReceivedEvent.UnloadingPermission).value mustBe UnloadingPermission
       }
 
       "transition to ArrivalRejected when receiving a ArrivalRejected event" in {
-        ArrivalSubmitted.transition(MessageReceivedEvent.ArrivalRejected).right.value mustBe ArrivalRejected
+        ArrivalSubmitted.transition(MessageReceivedEvent.ArrivalRejected).value mustBe ArrivalRejected
       }
 
       "transition to Unloading remarks Rejected when receiving a UnloadingRemarksRejected event" in {
-        ArrivalSubmitted.transition(MessageReceivedEvent.UnloadingRemarksRejected).right.value mustBe UnloadingRemarksRejected
+        ArrivalSubmitted.transition(MessageReceivedEvent.UnloadingRemarksRejected).value mustBe UnloadingRemarksRejected
       }
 
       "return an error message if any other event is provided" in {
@@ -118,13 +118,12 @@ class ArrivalStatusSpec extends SpecBase with ScalaCheckDrivenPropertyChecks wit
     "UnloadingRemarksSubmitted must " - {
 
       "transition to Unloading Remarks Rejected when receiving an UnloadingRemarksRejected event" in {
-        UnloadingRemarksSubmitted.transition(MessageReceivedEvent.UnloadingRemarksRejected).right.value mustBe UnloadingRemarksRejected
+        UnloadingRemarksSubmitted.transition(MessageReceivedEvent.UnloadingRemarksRejected).value mustBe UnloadingRemarksRejected
       }
 
       "transition to Unloading Remarks Rejected when receiving an UnloadingRemarksXMLSubmissionNegativeAcknowledgement event" in {
         UnloadingRemarksSubmitted
           .transition(MessageReceivedEvent.XMLSubmissionNegativeAcknowledgement)
-          .right
           .value mustBe UnloadingRemarksXMLSubmissionNegativeAcknowledgement
       }
 
@@ -134,11 +133,11 @@ class ArrivalStatusSpec extends SpecBase with ScalaCheckDrivenPropertyChecks wit
       }
 
       "transition to GoodsReceived when receiving a GoodsReleased event" in {
-        UnloadingRemarksSubmitted.transition(MessageReceivedEvent.GoodsReleased).right.value mustBe GoodsReleased
+        UnloadingRemarksSubmitted.transition(MessageReceivedEvent.GoodsReleased).value mustBe GoodsReleased
       }
 
       "transition to UnloadingPermission state when receiving an UnloadingPermission event" in {
-        UnloadingRemarksRejected.transition(MessageReceivedEvent.UnloadingPermission).right.value mustBe UnloadingPermission
+        UnloadingRemarksRejected.transition(MessageReceivedEvent.UnloadingPermission).value mustBe UnloadingPermission
       }
 
       "return an error message if any other event is provided" in {
@@ -161,18 +160,18 @@ class ArrivalStatusSpec extends SpecBase with ScalaCheckDrivenPropertyChecks wit
     "GoodsReleased will always transition to GoodsReleased" in {
       forAll(arbitrary[MessageReceivedEvent]) {
         messageReceivedEvent =>
-          GoodsReleased.transition(messageReceivedEvent).right.value mustBe GoodsReleased
+          GoodsReleased.transition(messageReceivedEvent).value mustBe GoodsReleased
       }
     }
 
     "ArrivalRejected must " - {
 
       "transition to ArrivalRejected state when receiving an ArrivalRejected event" in {
-        ArrivalRejected.transition(MessageReceivedEvent.ArrivalRejected).right.value mustBe ArrivalRejected
+        ArrivalRejected.transition(MessageReceivedEvent.ArrivalRejected).value mustBe ArrivalRejected
       }
 
       "transition to GoodsReleased state when receiving an GoodsReleased event" in {
-        ArrivalRejected.transition(MessageReceivedEvent.GoodsReleased).right.value mustBe GoodsReleased
+        ArrivalRejected.transition(MessageReceivedEvent.GoodsReleased).value mustBe GoodsReleased
       }
 
       "return an error message if any other event is provided" in {
@@ -188,7 +187,7 @@ class ArrivalStatusSpec extends SpecBase with ScalaCheckDrivenPropertyChecks wit
     "XMLSubmissionNegativeAcknowledgement must " - {
 
       "transition to XMLSubmissionNegativeAcknowledgement state when receiving an XMLSubmissionNegativeAcknowledgement event" in {
-        ArrivalXMLSubmissionNegativeAcknowledgement.transition(MessageReceivedEvent.XMLSubmissionNegativeAcknowledgement).right.value mustBe
+        ArrivalXMLSubmissionNegativeAcknowledgement.transition(MessageReceivedEvent.XMLSubmissionNegativeAcknowledgement).value mustBe
           ArrivalXMLSubmissionNegativeAcknowledgement
       }
 
@@ -203,46 +202,46 @@ class ArrivalStatusSpec extends SpecBase with ScalaCheckDrivenPropertyChecks wit
       }
 
       "IE917 for IE007" in {
-        val step1 = Initialized.transition(MessageReceivedEvent.ArrivalSubmitted).right.value
+        val step1 = Initialized.transition(MessageReceivedEvent.ArrivalSubmitted).value
 
         step1 mustEqual ArrivalSubmitted
 
-        val step2 = step1.transition(MessageReceivedEvent.XMLSubmissionNegativeAcknowledgement).right.value
+        val step2 = step1.transition(MessageReceivedEvent.XMLSubmissionNegativeAcknowledgement).value
 
         step2 mustEqual ArrivalXMLSubmissionNegativeAcknowledgement
 
-        val step3 = step2.transition(MessageReceivedEvent.ArrivalSubmitted).right.value
+        val step3 = step2.transition(MessageReceivedEvent.ArrivalSubmitted).value
 
         step3 mustEqual ArrivalSubmitted
 
       }
 
       "IE917 for IE044" in {
-        val step1 = Initialized.transition(MessageReceivedEvent.ArrivalSubmitted).right.value
+        val step1 = Initialized.transition(MessageReceivedEvent.ArrivalSubmitted).value
 
         step1 mustEqual ArrivalSubmitted
 
-        val step2 = step1.transition(MessageReceivedEvent.XMLSubmissionNegativeAcknowledgement).right.value
+        val step2 = step1.transition(MessageReceivedEvent.XMLSubmissionNegativeAcknowledgement).value
 
         step2 mustEqual ArrivalXMLSubmissionNegativeAcknowledgement
 
-        val step3 = step2.transition(MessageReceivedEvent.ArrivalSubmitted).right.value
+        val step3 = step2.transition(MessageReceivedEvent.ArrivalSubmitted).value
 
         step3 mustEqual ArrivalSubmitted
 
-        val step4 = step3.transition(MessageReceivedEvent.UnloadingPermission).right.value
+        val step4 = step3.transition(MessageReceivedEvent.UnloadingPermission).value
 
         step4 mustEqual UnloadingPermission
 
-        val step5 = step4.transition(MessageReceivedEvent.UnloadingRemarksSubmitted).right.value
+        val step5 = step4.transition(MessageReceivedEvent.UnloadingRemarksSubmitted).value
 
         step5 mustEqual UnloadingRemarksSubmitted
 
-        val step6 = step5.transition(MessageReceivedEvent.XMLSubmissionNegativeAcknowledgement).right.value
+        val step6 = step5.transition(MessageReceivedEvent.XMLSubmissionNegativeAcknowledgement).value
 
         step6 mustEqual UnloadingRemarksXMLSubmissionNegativeAcknowledgement
 
-        val step7 = step6.transition(MessageReceivedEvent.UnloadingRemarksSubmitted).right.value
+        val step7 = step6.transition(MessageReceivedEvent.UnloadingRemarksSubmitted).value
 
         step7 mustEqual UnloadingRemarksSubmitted
 
@@ -252,7 +251,7 @@ class ArrivalStatusSpec extends SpecBase with ScalaCheckDrivenPropertyChecks wit
     "UnloadingRemarksXMLSubmissionNegativeAcknowledgement must " - {
 
       "transition to XMLSubmissionNegativeAcknowledgement state when receiving an XMLSubmissionNegativeAcknowledgement event" in {
-        UnloadingRemarksXMLSubmissionNegativeAcknowledgement.transition(MessageReceivedEvent.XMLSubmissionNegativeAcknowledgement).right.value mustBe
+        UnloadingRemarksXMLSubmissionNegativeAcknowledgement.transition(MessageReceivedEvent.XMLSubmissionNegativeAcknowledgement).value mustBe
           UnloadingRemarksXMLSubmissionNegativeAcknowledgement
       }
 
@@ -267,46 +266,46 @@ class ArrivalStatusSpec extends SpecBase with ScalaCheckDrivenPropertyChecks wit
       }
 
       "IE917 for IE007" in {
-        val step1 = Initialized.transition(MessageReceivedEvent.ArrivalSubmitted).right.value
+        val step1 = Initialized.transition(MessageReceivedEvent.ArrivalSubmitted).value
 
         step1 mustEqual ArrivalSubmitted
 
-        val step2 = step1.transition(MessageReceivedEvent.XMLSubmissionNegativeAcknowledgement).right.value
+        val step2 = step1.transition(MessageReceivedEvent.XMLSubmissionNegativeAcknowledgement).value
 
         step2 mustEqual ArrivalXMLSubmissionNegativeAcknowledgement
 
-        val step3 = step2.transition(MessageReceivedEvent.ArrivalSubmitted).right.value
+        val step3 = step2.transition(MessageReceivedEvent.ArrivalSubmitted).value
 
         step3 mustEqual ArrivalSubmitted
 
       }
 
       "IE917 for IE044" in {
-        val step1 = Initialized.transition(MessageReceivedEvent.ArrivalSubmitted).right.value
+        val step1 = Initialized.transition(MessageReceivedEvent.ArrivalSubmitted).value
 
         step1 mustEqual ArrivalSubmitted
 
-        val step2 = step1.transition(MessageReceivedEvent.XMLSubmissionNegativeAcknowledgement).right.value
+        val step2 = step1.transition(MessageReceivedEvent.XMLSubmissionNegativeAcknowledgement).value
 
         step2 mustEqual ArrivalXMLSubmissionNegativeAcknowledgement
 
-        val step3 = step2.transition(MessageReceivedEvent.ArrivalSubmitted).right.value
+        val step3 = step2.transition(MessageReceivedEvent.ArrivalSubmitted).value
 
         step3 mustEqual ArrivalSubmitted
 
-        val step4 = step3.transition(MessageReceivedEvent.UnloadingPermission).right.value
+        val step4 = step3.transition(MessageReceivedEvent.UnloadingPermission).value
 
         step4 mustEqual UnloadingPermission
 
-        val step5 = step4.transition(MessageReceivedEvent.UnloadingRemarksSubmitted).right.value
+        val step5 = step4.transition(MessageReceivedEvent.UnloadingRemarksSubmitted).value
 
         step5 mustEqual UnloadingRemarksSubmitted
 
-        val step6 = step5.transition(MessageReceivedEvent.XMLSubmissionNegativeAcknowledgement).right.value
+        val step6 = step5.transition(MessageReceivedEvent.XMLSubmissionNegativeAcknowledgement).value
 
         step6 mustEqual UnloadingRemarksXMLSubmissionNegativeAcknowledgement
 
-        val step7 = step6.transition(MessageReceivedEvent.UnloadingRemarksSubmitted).right.value
+        val step7 = step6.transition(MessageReceivedEvent.UnloadingRemarksSubmitted).value
 
         step7 mustEqual UnloadingRemarksSubmitted
 
@@ -316,19 +315,19 @@ class ArrivalStatusSpec extends SpecBase with ScalaCheckDrivenPropertyChecks wit
     "UnloadingRemarksRejected must " - {
 
       "transition to UnloadingRemarksRejected state when receiving an UnloadingRemarksRejected event" in {
-        UnloadingRemarksRejected.transition(MessageReceivedEvent.UnloadingRemarksRejected).right.value mustBe UnloadingRemarksRejected
+        UnloadingRemarksRejected.transition(MessageReceivedEvent.UnloadingRemarksRejected).value mustBe UnloadingRemarksRejected
       }
 
       "transition to GoodsReleased state when receiving an GoodsReleased event" in {
-        UnloadingRemarksRejected.transition(MessageReceivedEvent.GoodsReleased).right.value mustBe GoodsReleased
+        UnloadingRemarksRejected.transition(MessageReceivedEvent.GoodsReleased).value mustBe GoodsReleased
       }
 
       "transition to UnloadingRemarksSubmitted state when receiving an UnloadingRemarksSubmitted event" in {
-        UnloadingRemarksRejected.transition(MessageReceivedEvent.UnloadingRemarksSubmitted).right.value mustBe UnloadingRemarksSubmitted
+        UnloadingRemarksRejected.transition(MessageReceivedEvent.UnloadingRemarksSubmitted).value mustBe UnloadingRemarksSubmitted
       }
 
       "transition to UnloadingPermissionSubmitted state when receiving an UnloadingPermission event" in {
-        UnloadingRemarksRejected.transition(MessageReceivedEvent.UnloadingPermission).right.value mustBe UnloadingPermission
+        UnloadingRemarksRejected.transition(MessageReceivedEvent.UnloadingPermission).value mustBe UnloadingPermission
       }
 
       "return an error message if any other event is provided" in {
@@ -350,15 +349,15 @@ class ArrivalStatusSpec extends SpecBase with ScalaCheckDrivenPropertyChecks wit
     "UnloadingPermission must " - {
 
       "transition to UnloadingPermission state when receiving an UnloadingPermission event" in {
-        UnloadingPermission.transition(MessageReceivedEvent.UnloadingPermission).right.value mustBe UnloadingPermission
+        UnloadingPermission.transition(MessageReceivedEvent.UnloadingPermission).value mustBe UnloadingPermission
       }
 
       "transition to UnloadingRemarksSubmitted state when receiving an UnloadingRemarksSubmitted event" in {
-        UnloadingPermission.transition(MessageReceivedEvent.UnloadingRemarksSubmitted).right.value mustBe UnloadingRemarksSubmitted
+        UnloadingPermission.transition(MessageReceivedEvent.UnloadingRemarksSubmitted).value mustBe UnloadingRemarksSubmitted
       }
 
       "transition to Goods Released state when receiving an GoodsReleased event" in {
-        UnloadingPermission.transition(MessageReceivedEvent.GoodsReleased).right.value mustBe GoodsReleased
+        UnloadingPermission.transition(MessageReceivedEvent.GoodsReleased).value mustBe GoodsReleased
       }
 
       "return an error message if any other event is provided" in {

--- a/test/models/ArrivalUpdateSpec.scala
+++ b/test/models/ArrivalUpdateSpec.scala
@@ -29,6 +29,9 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.libs.json.JsObject
 import play.api.libs.json.Json
+import java.time.Clock
+import java.time.ZoneOffset
+import java.time.Instant
 
 class ArrivalUpdateSpec
     extends SpecBase
@@ -39,6 +42,8 @@ class ArrivalUpdateSpec
     with MongoDateTimeFormats {
 
   implicit val eqArrivalStatusUpdate: Eq[ArrivalUpdate] = _ == _
+  val currentDateTime                                   = LocalDateTime.now.withSecond(0).withNano(0).toInstant(ZoneOffset.UTC)
+  implicit val clock: Clock                             = Clock.fixed(currentDateTime, ZoneOffset.UTC)
 
   "ArrivalUpdate" - {
 
@@ -116,7 +121,7 @@ class ArrivalUpdateSpec
           val expectedUpdateJson = Json.obj(
             "$set" -> Json.obj(
               s"messages.${messageStatusUpdate.messageId.index}.status" -> messageStatusUpdate.messageStatus,
-              "lastUpdated"                                             -> LocalDateTime.now.withSecond(0).withNano(0)
+              "lastUpdated"                                             -> LocalDateTime.now(clock).withSecond(0).withNano(0)
             )
           )
 
@@ -132,7 +137,7 @@ class ArrivalUpdateSpec
           val expectedUpdateJson = Json.obj(
             "$set" -> Json.obj(
               "status"      -> arrivalStatusUpdate.arrivalStatus,
-              "lastUpdated" -> LocalDateTime.now.withSecond(0).withNano(0)
+              "lastUpdated" -> LocalDateTime.now(clock).withSecond(0).withNano(0)
             )
           )
 
@@ -149,7 +154,7 @@ class ArrivalUpdateSpec
             "$set" -> Json.obj(
               "status"                                                                       -> compoundStatusUpdate.arrivalStatusUpdate.arrivalStatus,
               s"messages.${compoundStatusUpdate.messageStatusUpdate.messageId.index}.status" -> compoundStatusUpdate.messageStatusUpdate.messageStatus,
-              "lastUpdated"                                                                  -> LocalDateTime.now.withSecond(0).withNano(0)
+              "lastUpdated"                                                                  -> LocalDateTime.now(clock).withSecond(0).withNano(0)
             )
           )
 
@@ -168,7 +173,7 @@ class ArrivalUpdateSpec
               "movementReferenceNumber"             -> arrivalPutUpdate.movementReferenceNumber,
               "status"                              -> arrivalPutUpdate.arrivalUpdate.arrivalStatusUpdate.arrivalStatus,
               s"messages.$expectedMessageId.status" -> arrivalPutUpdate.arrivalUpdate.messageStatusUpdate.messageStatus,
-              "lastUpdated"                         -> LocalDateTime.now.withSecond(0).withNano(0),
+              "lastUpdated"                         -> LocalDateTime.now(clock).withSecond(0).withNano(0)
             )
           )
 

--- a/test/models/MessageIdSpec.scala
+++ b/test/models/MessageIdSpec.scala
@@ -35,7 +35,7 @@ class MessageIdSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChe
         value =>
           val expectedMessageIndex = value - 1
 
-          val result = pathBindable.bind("key", value.toString).right.value
+          val result = pathBindable.bind("key", value.toString).value
 
           result.index mustEqual expectedMessageIndex
       }

--- a/test/models/MessageSenderSpec.scala
+++ b/test/models/MessageSenderSpec.scala
@@ -94,7 +94,7 @@ class MessageSenderSpec extends AnyFreeSpec with Matchers with ScalaCheckPropert
 
       val messageSender = MessageSender(ArrivalId(123), 1)
 
-      pathBindable.bind("key", messageSender.toString).right.value mustEqual messageSender
+      pathBindable.bind("key", messageSender.toString).value mustEqual messageSender
     }
 
     "must unbind from a URL" in {


### PR DESCRIPTION
This adds an optional `updatedSince` query parameter to the `getAllArrivals` endpoint. This will allow API users to cut down the amount of data they need to fetch at one time.

I have also included the changes required to use the new artifact store due to the Bintray decommissioning.