### PR TITLE
CTDA-1294 Filter messages by received timestamp

### DIFF
--- a/app/controllers/MessagesController.scala
+++ b/app/controllers/MessagesController.scala
@@ -125,18 +125,9 @@ class MessagesController @Inject()(
     withMetricsTimerAction("get-all-arrival-messages") {
       authenticateForRead(arrivalId) {
         implicit request =>
-          val allMessages = request.arrival.messages.toList
-
-          val messagesSince = receivedSince
-            .map {
-              requestedDate =>
-                allMessages.count(_.receivedSince(requestedDate))
-            }
-            .getOrElse(allMessages.length)
-
-          countMessages.update(messagesSince)
-
-          Ok(Json.toJsObject(ResponseArrivalWithMessages.build(request.arrival, receivedSince)))
+          val response = ResponseArrivalWithMessages.build(request.arrival, receivedSince)
+          countMessages.update(response.messages.length)
+          Ok(Json.toJsObject(response))
       }
     }
 }

--- a/app/models/MovementMessage.scala
+++ b/app/models/MovementMessage.scala
@@ -39,9 +39,6 @@ sealed trait MovementMessage {
 
   def receivedBefore(requestedDate: OffsetDateTime): Boolean =
     dateTime.atOffset(ZoneOffset.UTC).isBefore(requestedDate)
-
-  def receivedSince(requestedDate: OffsetDateTime): Boolean =
-    !receivedBefore(requestedDate)
 }
 
 sealed trait XmlToJson extends Logging {

--- a/app/models/MovementMessage.scala
+++ b/app/models/MovementMessage.scala
@@ -16,14 +16,15 @@
 
 package models
 
-import java.time.LocalDateTime
-
 import logging.Logging
 import org.json.XML
 import play.api.libs.json.Json
 import play.api.libs.json._
 import utils.NodeSeqFormat
 
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
@@ -35,6 +36,12 @@ sealed trait MovementMessage {
   def message: NodeSeq
   def optStatus: Option[MessageStatus]
   def messageJson: JsObject
+
+  def receivedBefore(requestedDate: OffsetDateTime): Boolean =
+    dateTime.atOffset(ZoneOffset.UTC).isBefore(requestedDate)
+
+  def receivedSince(requestedDate: OffsetDateTime): Boolean =
+    !receivedBefore(requestedDate)
 }
 
 sealed trait XmlToJson extends Logging {

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -7,7 +7,7 @@ GET     /movements/arrivals/:arrivalId                          controllers.Move
 PUT     /movements/arrivals/:arrivalId                          controllers.MovementsController.putArrival(arrivalId: ArrivalId)
 
 POST    /movements/arrivals/:arrivalId/messages                 controllers.MessagesController.post(arrivalId: ArrivalId)
-GET     /movements/arrivals/:arrivalId/messages                 controllers.MessagesController.getMessages(arrivalId: ArrivalId)
+GET     /movements/arrivals/:arrivalId/messages                 controllers.MessagesController.getMessages(arrivalId: ArrivalId, receivedSince: Option[OffsetDateTime] ?= None)
 
 GET     /movements/arrivals/:arrivalId/messages/summary         controllers.MessagesSummaryController.messagesSummary(arrivalId: ArrivalId)
 GET     /movements/arrivals/:arrivalId/messages/:messageId      controllers.MessagesController.getMessage(arrivalId: ArrivalId, messageId: MessageId)

--- a/test/models/response/ResponseArrivalWithMessagesSpec.scala
+++ b/test/models/response/ResponseArrivalWithMessagesSpec.scala
@@ -16,11 +16,6 @@
 
 package models
 
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.Month
-
 import base.SpecBase
 import cats.data.NonEmptyList
 import generators.ModelGenerators
@@ -33,8 +28,13 @@ import org.scalatest.concurrent.IntegrationPatience
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import utils.Format
 
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.Month
 import scala.xml.NodeSeq
 import scala.xml.Utility.trim
+import java.time.ZoneOffset
 
 class ResponseArrivalWithMessagesSpec extends SpecBase with ScalaCheckPropertyChecks with ModelGenerators with BeforeAndAfterEach with IntegrationPatience {
   val localDate     = LocalDate.now()
@@ -88,10 +88,18 @@ class ResponseArrivalWithMessagesSpec extends SpecBase with ScalaCheckPropertyCh
 
   "ResponseArrivalWithMessages" - {
     "must populate updated field from lastUpdated in Arrival" in {
-      val responseArrivalWithMessages = ResponseArrivalWithMessages.build(initializedArrival)
+      val responseArrivalWithMessages = ResponseArrivalWithMessages.build(initializedArrival, receivedSince = None)
+
+      responseArrivalWithMessages.messages mustNot be(empty)
 
       responseArrivalWithMessages.updated mustEqual initializedArrival.lastUpdated
       responseArrivalWithMessages.updated must not equal initializedArrival.updated
+    }
+
+    "must filter messages by requested date" in {
+      val requestedDate               = localDateTime.plusSeconds(1).atOffset(ZoneOffset.UTC)
+      val responseArrivalWithMessages = ResponseArrivalWithMessages.build(initializedArrival, receivedSince = Some(requestedDate))
+      responseArrivalWithMessages.messages mustBe empty
     }
   }
 }


### PR DESCRIPTION
Allows users to filter the GET all message endpoint by received datetime of the message.