### PR TITLE
Fix date filtering implementation and tests

### DIFF
--- a/app/repositories/ArrivalMovementRepository.scala
+++ b/app/repositories/ArrivalMovementRepository.scala
@@ -190,7 +190,7 @@ class ArrivalMovementRepository @Inject()(
         val selector   = Json.obj("eoriNumber" -> eoriNumber, "channel" -> channelFilter) ++ dateFilter
 
         collection.flatMap {
-          _.find(Json.obj("eoriNumber" -> eoriNumber, "channel" -> channelFilter), Some(ResponseArrival.projection))
+          _.find(selector, Some(ResponseArrival.projection))
             .sort(Json.obj("lastUpdated" -> -1))
             .cursor[ResponseArrival]()
             .collect[Seq](appConfig.maxRowsReturned(channelFilter), Cursor.FailOnError())

--- a/it/repositories/ArrivalMovementRepositorySpec.scala
+++ b/it/repositories/ArrivalMovementRepositorySpec.scala
@@ -586,10 +586,10 @@ class ArrivalMovementRepositorySpec
 
       "must filter results by lastUpdated when updatedSince parameter is provided" in {
 
-        val arrivalMovement1 = arbitrary[Arrival].sample.value.copy(eoriNumber = eoriNumber, channel = api, lastUpdated = LocalDateTime.of(2021, 4, 30, 9, 30, 31))
-        val arrivalMovement2 = arbitrary[Arrival].sample.value.copy(eoriNumber = eoriNumber, channel = api, lastUpdated = LocalDateTime.of(2021, 4, 30, 9, 35, 32))
-        val arrivalMovement3 = arbitrary[Arrival].sample.value.copy(eoriNumber = eoriNumber, channel = api, lastUpdated = LocalDateTime.of(2021, 4, 30, 9, 30, 21))
-        val arrivalMovement4 = arbitrary[Arrival].sample.value.copy(eoriNumber = eoriNumber, channel = api, lastUpdated = LocalDateTime.of(2021, 4, 30, 10, 15, 16))
+        val arrivalMovement1 = arbitrary[Arrival].sample.value.copy(eoriNumber = eoriNumber, channel = web, lastUpdated = LocalDateTime.of(2021, 4, 30, 9, 30, 31))
+        val arrivalMovement2 = arbitrary[Arrival].sample.value.copy(eoriNumber = eoriNumber, channel = web, lastUpdated = LocalDateTime.of(2021, 4, 30, 9, 35, 32))
+        val arrivalMovement3 = arbitrary[Arrival].sample.value.copy(eoriNumber = eoriNumber, channel = web, lastUpdated = LocalDateTime.of(2021, 4, 30, 12, 30, 21))
+        val arrivalMovement4 = arbitrary[Arrival].sample.value.copy(eoriNumber = eoriNumber, channel = web, lastUpdated = LocalDateTime.of(2021, 4, 30, 10, 15, 16))
 
         val app = appBuilder.build()
         running(app) {
@@ -605,9 +605,10 @@ class ArrivalMovementRepositorySpec
               db.collection[JSONCollection](ArrivalMovementRepository.collectionName).insert(false).many(jsonArr)
           }.futureValue
 
+          // We must use the web channel for this test as the API max rows returned in integration test config is 2
           val dateTime = OffsetDateTime.of(LocalDateTime.of(2021, 4, 30, 10, 30, 32), ZoneOffset.ofHours(1))
-          val actual = service.fetchAllArrivals(eoriNumber, api, Some(dateTime)).futureValue.toSet
-          val expected = Set(arrivalMovement2, arrivalMovement4).map(ResponseArrival.build)
+          val actual = service.fetchAllArrivals(eoriNumber, web, Some(dateTime)).futureValue.toSet
+          val expected = Set(arrivalMovement3, arrivalMovement4, arrivalMovement2).map(ResponseArrival.build)
 
           actual mustEqual expected
         }


### PR DESCRIPTION
I think the date filtering selector was lost to a merge conflict. I have restored that now! 

Unfortunately the test for this was still passing due to the way that the capping was implemented - the last 2 results were returned in reverse updated order due to the capping config for api.maxRowsReturned being 2, which had the same effect as the date filter in the integration tests. I've updated the test to use the web channel.