### PR TITLE
CTDA-1481 Add request ID to push notification body

### DIFF
--- a/app/connectors/PushPullNotificationConnector.scala
+++ b/app/connectors/PushPullNotificationConnector.scala
@@ -19,16 +19,18 @@ package connectors
 import com.google.inject.Inject
 import config.AppConfig
 import config.Constants
+import models.ArrivalMessageNotification
 import models.Box
 import models.BoxId
+import play.api.http.ContentTypes
+import play.api.http.HeaderNames
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.HttpClient
-import uk.gov.hmrc.http.UpstreamErrorResponse
 import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.UpstreamErrorResponse
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import scala.xml.NodeSeq
 
 class PushPullNotificationConnector @Inject()(config: AppConfig, http: HttpClient) {
 
@@ -42,12 +44,13 @@ class PushPullNotificationConnector @Inject()(config: AppConfig, http: HttpClien
     http.GET[Either[UpstreamErrorResponse, Box]](url, queryParams)
   }
 
-  def postNotification(boxId: BoxId, body: NodeSeq)(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Either[UpstreamErrorResponse, Unit]] = {
+  def postNotification(boxId: BoxId, notification: ArrivalMessageNotification)(implicit ec: ExecutionContext,
+                                                                               hc: HeaderCarrier): Future[Either[UpstreamErrorResponse, Unit]] = {
     val url = s"${config.pushPullUrl}/box/${boxId.value}/notifications"
     val headers = Seq(
-      "Content-Type" -> "application/xml"
+      HeaderNames.CONTENT_TYPE -> ContentTypes.JSON
     )
 
-    http.POSTString[Either[UpstreamErrorResponse, Unit]](url, body.toString, headers)
+    http.POST[ArrivalMessageNotification, Either[UpstreamErrorResponse, Unit]](url, notification, headers)
   }
 }

--- a/app/models/ArrivalMessageNotification.scala
+++ b/app/models/ArrivalMessageNotification.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import controllers.actions.InboundMessageRequest
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+import utils.NodeSeqFormat._
+
+import java.time.LocalDateTime
+import scala.xml.NodeSeq
+
+case class ArrivalMessageNotification(
+  arrivalId: ArrivalId,
+  messageId: Int,
+  received: LocalDateTime,
+  messageType: MessageType,
+  body: NodeSeq
+)
+
+object ArrivalMessageNotification {
+  private def requestId(arrivalId: ArrivalId): String =
+    s"/customs/transits/movements/arrivals/${arrivalId.index}"
+
+  implicit val writesArrivalId: Writes[ArrivalId] = Writes.of[String].contramap(_.index.toString)
+
+  private val writesArrivalMessageNotification: OWrites[ArrivalMessageNotification] =
+    (
+      (__ \ "arrivalId").write[ArrivalId] and
+        (__ \ "messageId").write[String].contramap[Int](_.toString) and
+        (__ \ "received").write[LocalDateTime] and
+        (__ \ "messageType").write[MessageType] and
+        (__ \ "body").write[NodeSeq]
+    )(unlift(ArrivalMessageNotification.unapply))
+
+  implicit val writesArrivalMessageNotificationWithRequestId: OWrites[ArrivalMessageNotification] =
+    OWrites.transform(writesArrivalMessageNotification) {
+      (arrival, obj) =>
+        obj ++ Json.obj("requestId" -> requestId(arrival.arrivalId))
+    }
+
+  def fromRequest(request: InboundMessageRequest[NodeSeq], timestamp: LocalDateTime): ArrivalMessageNotification =
+    ArrivalMessageNotification(
+      request.arrivalRequest.arrival.arrivalId,
+      request.arrivalRequest.arrival.messages.length,
+      timestamp,
+      request.message.messageType.messageType,
+      request.body
+    )
+}

--- a/app/models/ParseError.scala
+++ b/app/models/ParseError.scala
@@ -16,7 +16,9 @@
 
 package models
 
-trait ParseError
+sealed abstract class ParseError {
+  def message: String
+}
 
 object ParseError {
   case class LocalDateParseFailure(message: String)        extends ParseError
@@ -24,5 +26,5 @@ object ParseError {
   case class InvalidRootNode(message: String)              extends ParseError
   case class EmptyMovementReferenceNumber(message: String) extends ParseError
   case class EmptyNodeSeq(message: String)                 extends ParseError
-
+  case class MesSenMES3Failure(message: String)            extends ParseError
 }

--- a/app/services/PushPullNotificationService.scala
+++ b/app/services/PushPullNotificationService.scala
@@ -16,20 +16,19 @@
 
 package services
 
-import uk.gov.hmrc.http.HeaderCarrier
-
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
+import connectors.PushPullNotificationConnector
+import models.ArrivalMessageNotification
 import models.Box
 import models.BoxId
-import connectors.PushPullNotificationConnector
-import javax.inject.Inject
-import uk.gov.hmrc.http.UpstreamErrorResponse
 import play.api.Logging
 import play.api.http.Status._
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.UpstreamErrorResponse
 
+import javax.inject.Inject
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
 import scala.util.control.NonFatal
-import scala.xml.NodeSeq
 
 class PushPullNotificationService @Inject()(connector: PushPullNotificationConnector) extends Logging {
 
@@ -48,9 +47,9 @@ class PushPullNotificationService @Inject()(connector: PushPullNotificationConne
           None
       }
 
-  def sendPushNotification(boxId: BoxId, body: NodeSeq)(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Unit] =
+  def sendPushNotification(boxId: BoxId, notification: ArrivalMessageNotification)(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Unit] =
     connector
-      .postNotification(boxId, body)
+      .postNotification(boxId, notification)
       .map {
         case Left(UpstreamErrorResponse(message, statusCode, _, _)) =>
           logger.warn(s"Error $statusCode received while sending notification for boxId $boxId: $message")

--- a/app/utils/XMLTransformer.scala
+++ b/app/utils/XMLTransformer.scala
@@ -20,7 +20,7 @@ import cats.data.ReaderT
 import logging.Logging
 import models.ArrivalId
 import models.MessageSender
-import models.ParseError
+import models.ParseError.MesSenMES3Failure
 import services.XmlMessageParser.ParseHandler
 
 import scala.xml._
@@ -28,8 +28,6 @@ import scala.xml.transform.RewriteRule
 import scala.xml.transform.RuleTransformer
 
 object XMLTransformer extends Logging {
-
-  case class MesSenMES3Failure(message: String) extends ParseError
 
   def addXmlNode(existingNode: String, key: String, value: String, inputXml: NodeSeq): NodeSeq =
     createRuleTransformer(existingNode, key, value).transform(inputXml.head)

--- a/test/utils/XMLTransformerSpec.scala
+++ b/test/utils/XMLTransformerSpec.scala
@@ -17,10 +17,10 @@
 package utils
 
 import models.ArrivalId
+import models.ParseError.MesSenMES3Failure
 import org.scalatest.StreamlinedXmlEquality
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import utils.XMLTransformer.MesSenMES3Failure
 
 import scala.xml.NodeSeq
 


### PR DESCRIPTION
This changes the push notifications sent from the arrivals backend so that it produces a JSON body that replicates the structure of the [HateosArrivalResponseMessage](https://github.com/hmrc/common-transit-convention-traders/blob/master/app/models/response/HateoasArrivalResponseMessage.scala) from the public API.

It also adds a request ID to this JSON body as a URI for the arrival movement in the API so that third party developers can correlate messages with a particular arrival.