### PR TITLE
CTDA-1535 Add message ID to message body and migrate saved messages

### DIFF
--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -26,6 +26,7 @@ import controllers.actions.AuthenticatedGetOptionalArrivalForWriteActionProvider
 import repositories.ArrivalMovementRepository
 import utils.MessageTranslation
 import java.time.Clock
+import migrations.MigrationRunner
 
 class Module extends AbstractModule {
 
@@ -38,5 +39,6 @@ class Module extends AbstractModule {
     bind(classOf[MessageTranslation]).asEagerSingleton()
     bind(classOf[StreamLoggingConfig]).to(classOf[StreamLoggingConfigImpl]).asEagerSingleton()
     bind(classOf[Clock]).toInstance(Clock.systemUTC)
+    bind(classOf[MigrationRunner]).asEagerSingleton()
   }
 }

--- a/app/controllers/MessagesController.scala
+++ b/app/controllers/MessagesController.scala
@@ -78,7 +78,7 @@ class MessagesController @Inject()(
             val messageType = request.message.messageType.messageType
 
             arrivalMovementService
-              .makeOutboundMessage(arrivalId, arrival.nextMessageCorrelationId, messageType)(request.arrivalRequest.request.body) match {
+              .makeOutboundMessage(arrivalId, arrival.nextMessageId, arrival.nextMessageCorrelationId, messageType)(request.arrivalRequest.request.body) match {
               case Right(message) =>
                 submitMessageService
                   .submitMessage(arrivalId, arrival.nextMessageId, message, request.message.nextState, arrival.channel)
@@ -115,8 +115,8 @@ class MessagesController @Inject()(
         implicit request =>
           val messages = request.arrival.messages.toList
 
-          if (messages.isDefinedAt(messageId.index) && !messages(messageId.index).optStatus.contains(SubmissionFailed))
-            Ok(Json.toJsObject(ResponseMovementMessage.build(arrivalId, messageId, messages(messageId.index))))
+          if (messages.isDefinedAt(messageId.index - 1) && !messages(messageId.index - 1).optStatus.contains(SubmissionFailed))
+            Ok(Json.toJsObject(ResponseMovementMessage.build(arrivalId, messageId, messages(messageId.index - 1))))
           else NotFound
       }
     }

--- a/app/controllers/MessagesController.scala
+++ b/app/controllers/MessagesController.scala
@@ -115,8 +115,8 @@ class MessagesController @Inject()(
         implicit request =>
           val messages = request.arrival.messages.toList
 
-          if (messages.isDefinedAt(messageId.index - 1) && !messages(messageId.index - 1).optStatus.contains(SubmissionFailed))
-            Ok(Json.toJsObject(ResponseMovementMessage.build(arrivalId, messageId, messages(messageId.index - 1))))
+          if (messages.isDefinedAt(messageId.index) && !messages(messageId.index).optStatus.contains(SubmissionFailed))
+            Ok(Json.toJsObject(ResponseMovementMessage.build(arrivalId, messageId, messages(messageId.index))))
           else NotFound
       }
     }

--- a/app/controllers/MovementsController.scala
+++ b/app/controllers/MovementsController.scala
@@ -118,7 +118,9 @@ class MovementsController @Inject()(
           request.arrival match {
             case Some(arrival) if allMessageUnsent(arrival.messages) =>
               arrivalMovementService
-                .makeOutboundMessage(arrival.arrivalId, arrival.nextMessageCorrelationId, MessageType.ArrivalNotification)(request.body) match {
+                .makeOutboundMessage(arrival.arrivalId, arrival.nextMessageId, arrival.nextMessageCorrelationId, MessageType.ArrivalNotification)(
+                  request.body
+                ) match {
                 case Right(message) =>
                   submitMessageService
                     .submitMessage(arrival.arrivalId, arrival.nextMessageId, message, ArrivalStatus.ArrivalSubmitted, request.channel)
@@ -185,7 +187,7 @@ class MovementsController @Inject()(
       authenticateForWrite(arrivalId).async(parse.xml) {
         implicit request: ArrivalRequest[NodeSeq] =>
           arrivalMovementService
-            .messageAndMrn(arrivalId, request.arrival.nextMessageCorrelationId)(request.body) match {
+            .messageAndMrn(arrivalId, request.arrival.nextMessageId, request.arrival.nextMessageCorrelationId)(request.body) match {
             case Right((message, mrn)) =>
               submitMessageService
                 .submitIe007Message(arrivalId, request.arrival.nextMessageId, message, mrn, request.channel)

--- a/app/controllers/NCTSMessageController.scala
+++ b/app/controllers/NCTSMessageController.scala
@@ -84,6 +84,7 @@ class NCTSMessageController @Inject()(
 
           val processingResult =
             saveMessageService.validateXmlAndSaveMessage(
+              request.arrivalRequest.arrival.nextMessageId,
               xml,
               messageSender,
               messageInbound.messageType,

--- a/app/migrations/MigrationRunner.scala
+++ b/app/migrations/MigrationRunner.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package migrations
+
+import com.github.cloudyrock.mongock.driver.mongodb.sync.v4.driver.MongoSync4Driver
+import com.github.cloudyrock.standalone.MongockStandalone
+import com.github.cloudyrock.standalone.event.StandaloneMigrationSuccessEvent
+import com.mongodb.ConnectionString
+import com.mongodb.client.MongoClients
+import com.mongodb.connection.ClusterType
+import play.api.Configuration
+import play.api.Logging
+
+import javax.inject.Inject
+import javax.inject.Singleton
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.Promise
+
+@Singleton
+class MigrationRunner @Inject()(config: Configuration)(implicit ec: ExecutionContext) extends Logging {
+
+  private lazy val migrationsCompletedPromise = Promise[StandaloneMigrationSuccessEvent]()
+  lazy val migrationsCompleted                = migrationsCompletedPromise.future
+
+  def makeMongockRunner(completionPromise: Promise[StandaloneMigrationSuccessEvent]) = {
+    val mongoDbUri  = new ConnectionString(config.get[String]("mongodb.uri"))
+    val mongoClient = MongoClients.create(mongoDbUri)
+    val mongoDriver = MongoSync4Driver.withDefaultLock(mongoClient, mongoDbUri.getDatabase())
+
+    val clusterType = mongoClient.getClusterDescription.getType
+    if (clusterType == ClusterType.STANDALONE || clusterType == ClusterType.UNKNOWN) {
+      mongoDriver.disableTransaction()
+    }
+
+    mongoDriver.setIndexCreation(true)
+
+    MongockStandalone
+      .builder()
+      .setDriver(mongoDriver)
+      .addChangeLogsScanPackage("migrations.changelogs")
+      .setMigrationStartedListener(
+        () => logger.info("Started Mongock migrations")
+      )
+      .setMigrationSuccessListener {
+        successEvent =>
+          logger.info("Finished Mongock migrations successfully")
+          completionPromise.success(successEvent)
+      }
+      .setMigrationFailureListener {
+        failureEvent =>
+          val exception = failureEvent.getException
+          logger.error("Mongock migrations failed", exception)
+          completionPromise.failure(exception)
+      }
+      .buildRunner()
+  }
+
+  def runMigrations(): Future[StandaloneMigrationSuccessEvent] =
+    Future {
+      val completionPromise = Promise[StandaloneMigrationSuccessEvent]()
+      makeMongockRunner(completionPromise).execute()
+      completionPromise.future
+    }.flatten
+
+  makeMongockRunner(migrationsCompletedPromise).execute()
+}

--- a/app/migrations/changelogs/MovementsChangeLog.scala
+++ b/app/migrations/changelogs/MovementsChangeLog.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package migrations.changelogs
+
+import cats.syntax.all._
+import com.github.cloudyrock.mongock.ChangeLog
+import com.github.cloudyrock.mongock.ChangeSet
+import com.mongodb.client.MongoDatabase
+import com.mongodb.client.model._
+import org.bson.Document
+import repositories.ArrivalMovementRepository
+
+import scala.collection.JavaConverters._
+
+@ChangeLog(order = "001")
+class MovementsChangeLog {
+
+  @ChangeSet(order = "001", id = "addMessageIdToMessages", author = "transit-movements-trader-at-destination")
+  def addMessageIdToMessages(mongo: MongoDatabase): Unit = {
+    val collection = mongo.getCollection(ArrivalMovementRepository.collectionName)
+
+    collection
+      .find()
+      .asScala
+      .foreach {
+        doc =>
+          val messages = doc
+            .getList("messages", classOf[Document])
+            .asScala
+            .toList
+
+          if (messages.nonEmpty) {
+            collection.updateOne(
+              Filters.eq("_id", doc.getInteger("_id")),
+              Updates.combine(
+                messages.mapWithIndex {
+                  case (_, index) =>
+                    Updates.set(s"messages.$index.messageId", index + 1)
+                }.asJava
+              )
+            )
+          }
+      }
+  }
+}

--- a/app/models/Arrival.scala
+++ b/app/models/Arrival.scala
@@ -16,12 +16,11 @@
 
 package models
 
-import java.time.LocalDateTime
-import play.api.libs.json._
-import play.api.libs.functional.syntax._
 import cats.data._
-import cats.implicits._
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
 
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 case class Arrival(
@@ -38,10 +37,10 @@ case class Arrival(
   notificationBox: Option[Box]
 ) {
 
-  lazy val nextMessageId: MessageId = MessageId.fromIndex(messages.length)
+  lazy val nextMessageId: MessageId = MessageId(messages.length + 1)
 
   lazy val messagesWithId: NonEmptyList[(MovementMessage, MessageId)] =
-    messages.mapWithIndex(_ -> MessageId.fromIndex(_))
+    messages.map(msg => msg -> msg.messageId)
 
   private val obfuscatedEori: String          = s"ending ${eoriNumber.takeRight(7)}"
   private val isoFormatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
@@ -97,4 +96,6 @@ object Arrival {
         (__ \ "notificationBox").writeNullable[Box]
     )(unlift(Arrival.unapply))
 
+  implicit def formatsArrival(implicit write: Writes[LocalDateTime]): OFormat[Arrival] =
+    OFormat(readsArrival, writesArrival)
 }

--- a/app/models/ArrivalMessageNotification.scala
+++ b/app/models/ArrivalMessageNotification.scala
@@ -43,7 +43,7 @@ object ArrivalMessageNotification {
       (__ \ "messageUri").write[String] and
         (__ \ "requestId").write[String] and
         (__ \ "arrivalId").write[ArrivalId] and
-        (__ \ "messageId").write[String].contramap[MessageId](_.publicValue.toString) and
+        (__ \ "messageId").write[MessageId] and
         (__ \ "received").write[LocalDateTime] and
         (__ \ "messageType").write[MessageType]
     )(unlift(ArrivalMessageNotification.unapply))
@@ -55,10 +55,10 @@ object ArrivalMessageNotification {
     }
 
   def fromRequest(request: InboundMessageRequest[NodeSeq], timestamp: LocalDateTime): ArrivalMessageNotification = {
-    val messageId  = MessageId.fromIndex(request.arrivalRequest.arrival.messages.length)
+    val messageId  = request.arrivalRequest.arrival.nextMessageId
     val arrivalUrl = requestId(request.arrivalRequest.arrival.arrivalId)
     ArrivalMessageNotification(
-      s"$arrivalUrl/messages/${messageId.publicValue}",
+      s"$arrivalUrl/messages/${messageId.index}",
       arrivalUrl,
       request.arrivalRequest.arrival.arrivalId,
       messageId,

--- a/app/models/ArrivalMessageNotification.scala
+++ b/app/models/ArrivalMessageNotification.scala
@@ -58,7 +58,7 @@ object ArrivalMessageNotification {
     val messageId  = request.arrivalRequest.arrival.nextMessageId
     val arrivalUrl = requestId(request.arrivalRequest.arrival.arrivalId)
     ArrivalMessageNotification(
-      s"$arrivalUrl/messages/${messageId.index}",
+      s"$arrivalUrl/messages/${messageId.value}",
       arrivalUrl,
       request.arrivalRequest.arrival.arrivalId,
       messageId,

--- a/app/models/ArrivalSelector.scala
+++ b/app/models/ArrivalSelector.scala
@@ -35,22 +35,25 @@ object ArrivalSelector {
 final case class ArrivalIdSelector(arrivalId: ArrivalId) extends ArrivalSelector
 
 object ArrivalIdSelector {
+
   implicit val writes: OWrites[ArrivalIdSelector] = OWrites(
     arrivalIdSelector =>
       Json.obj(
         "_id" -> arrivalIdSelector.arrivalId
-    ))
+    )
+  )
 }
 
 final case class MessageSelector(arrivalId: ArrivalId, messageId: MessageId) extends ArrivalSelector
 
 object MessageSelector {
+
   implicit val writes: OWrites[MessageSelector] = OWrites(
     messageSelector =>
       Json.obj(
         "$and" -> Json.arr(
-          Json.obj("_id"                                                     -> messageSelector.arrivalId),
-          Json.obj(s"messages.${messageSelector.messageId.index - 1}.status" -> Json.obj("$exists" -> true))
+          Json.obj("_id"                                                 -> messageSelector.arrivalId),
+          Json.obj(s"messages.${messageSelector.messageId.index}.status" -> Json.obj("$exists" -> true))
         )
     )
   )

--- a/app/models/ArrivalSelector.scala
+++ b/app/models/ArrivalSelector.scala
@@ -49,8 +49,8 @@ object MessageSelector {
     messageSelector =>
       Json.obj(
         "$and" -> Json.arr(
-          Json.obj("_id"                                                 -> messageSelector.arrivalId),
-          Json.obj(s"messages.${messageSelector.messageId.index}.status" -> Json.obj("$exists" -> true))
+          Json.obj("_id"                                                     -> messageSelector.arrivalId),
+          Json.obj(s"messages.${messageSelector.messageId.index - 1}.status" -> Json.obj("$exists" -> true))
         )
     )
   )

--- a/app/models/ArrivalUpdate.scala
+++ b/app/models/ArrivalUpdate.scala
@@ -67,8 +67,8 @@ object MessageStatusUpdate extends MongoDateTimeFormats {
         Json.obj(
           "$set" ->
             Json.obj(
-              s"messages.${value.messageId.index}.status" -> value.messageStatus,
-              "lastUpdated"                               -> LocalDateTime.now(clock)
+              s"messages.${value.messageId.index - 1}.status" -> value.messageStatus,
+              "lastUpdated"                                   -> LocalDateTime.now(clock)
             )
       )
     )

--- a/app/models/ArrivalUpdate.scala
+++ b/app/models/ArrivalUpdate.scala
@@ -67,8 +67,8 @@ object MessageStatusUpdate extends MongoDateTimeFormats {
         Json.obj(
           "$set" ->
             Json.obj(
-              s"messages.${value.messageId.index - 1}.status" -> value.messageStatus,
-              "lastUpdated"                                   -> LocalDateTime.now(clock)
+              s"messages.${value.messageId.index}.status" -> value.messageStatus,
+              "lastUpdated"                               -> LocalDateTime.now(clock)
             )
       )
     )

--- a/app/models/MessageId.scala
+++ b/app/models/MessageId.scala
@@ -20,7 +20,9 @@ import play.api.mvc.PathBindable
 import play.api.libs.json.Format
 import play.api.libs.json.Json
 
-case class MessageId(index: Int)
+case class MessageId(value: Int) {
+  def index: Int = value - 1
+}
 
 object MessageId {
 
@@ -28,9 +30,10 @@ object MessageId {
 
   implicit val formatMessageId: Format[MessageId] = Json.valueFormat[MessageId]
 
-  implicit val pathBindableMessageId: PathBindable[MessageId] = new PathBindable[MessageId] {
+  implicit def pathBindableMessageId(implicit intBindable: PathBindable[Int]): PathBindable[MessageId] = new PathBindable[MessageId] {
+
     override def bind(key: String, value: String): Either[String, MessageId] =
-      implicitly[PathBindable[Int]]
+      intBindable
         .bind(key, value)
         .fold(
           Left(_),
@@ -40,10 +43,8 @@ object MessageId {
           }
         )
 
-    override def unbind(key: String, value: MessageId): String = {
-      val MessageId(messageId) = value
-      messageId.toString
-    }
+    override def unbind(key: String, messageId: MessageId): String =
+      intBindable.unbind(key, messageId.value)
   }
 
 }

--- a/app/models/MessageId.scala
+++ b/app/models/MessageId.scala
@@ -17,25 +17,16 @@
 package models
 
 import play.api.mvc.PathBindable
+import play.api.libs.json.Format
+import play.api.libs.json.Json
 
-final class MessageId private (val index: Int) {
-  override def toString: String = s"MessageId($index)"
-
-  override def equals(obj: Any): Boolean = obj match {
-    case x: MessageId => x.index == this.index
-    case _            => false
-  }
-
-  def publicValue: Int = index + 1
-}
+case class MessageId(index: Int)
 
 object MessageId {
 
-  def fromMessageIdValue(messageId: Int): Option[MessageId] = if (messageId > 0) Some(new MessageId(messageId - 1)) else None
+  def fromMessageIdValue(messageId: Int): Option[MessageId] = if (messageId > 0) Some(new MessageId(messageId)) else None
 
-  def unapply(arg: MessageId): Some[Int] = Some(arg.index + 1)
-
-  def fromIndex(index: Int): MessageId = new MessageId(index)
+  implicit val formatMessageId: Format[MessageId] = Json.valueFormat[MessageId]
 
   implicit val pathBindableMessageId: PathBindable[MessageId] = new PathBindable[MessageId] {
     override def bind(key: String, value: String): Either[String, MessageId] =
@@ -43,7 +34,7 @@ object MessageId {
         .bind(key, value)
         .fold(
           Left(_),
-          fromMessageIdValue _ andThen {
+          fromMessageIdValue(_) match {
             case Some(messageId) => Right(messageId)
             case x               => Left(s"Invalid MessageId. The MessageId must be > 0, instead got $x")
           }

--- a/app/services/MessageRetrievalService.scala
+++ b/app/services/MessageRetrievalService.scala
@@ -28,8 +28,8 @@ class MessageRetrievalService @Inject()(arrivalMessageSummaryService: ArrivalMes
         {
           val messages = arrival.messages.toList
 
-          if (messages.isDefinedAt(messageId.index)) {
-            Some(ResponseMovementMessage.build(arrival.arrivalId, messageId, messages(messageId.index)))
+          if (messages.isDefinedAt(messageId.index - 1)) {
+            Some(ResponseMovementMessage.build(arrival.arrivalId, messageId, messages(messageId.index - 1)))
           } else {
             None
           }

--- a/app/services/MessageRetrievalService.scala
+++ b/app/services/MessageRetrievalService.scala
@@ -28,8 +28,8 @@ class MessageRetrievalService @Inject()(arrivalMessageSummaryService: ArrivalMes
         {
           val messages = arrival.messages.toList
 
-          if (messages.isDefinedAt(messageId.index - 1)) {
-            Some(ResponseMovementMessage.build(arrival.arrivalId, messageId, messages(messageId.index - 1)))
+          if (messages.isDefinedAt(messageId.index)) {
+            Some(ResponseMovementMessage.build(arrival.arrivalId, messageId, messages(messageId.index)))
           } else {
             None
           }

--- a/app/testOnly/services/TestDataGenerator.scala
+++ b/app/testOnly/services/TestDataGenerator.scala
@@ -33,6 +33,7 @@ import java.time.LocalDateTime
 import javax.inject.Inject
 import scala.xml.Elem
 import scala.xml.XML
+import models.MessageId
 
 private[services] class TestDataGenerator @Inject()(clock: Clock) {
 
@@ -42,7 +43,7 @@ private[services] class TestDataGenerator @Inject()(clock: Clock) {
 
     val xml = TestDataXMLGenerator.arrivalNotification(mrn.format, eori.format)
 
-    val movementMessage = MovementMessageWithStatus(dateTime, ArrivalNotification, xml, MessageStatus.SubmissionSucceeded, 1)
+    val movementMessage = MovementMessageWithStatus(MessageId(1), dateTime, ArrivalNotification, xml, MessageStatus.SubmissionSucceeded, 1)
 
     Arrival(
       arrivalId,

--- a/conf/application-json-logger.xml
+++ b/conf/application-json-logger.xml
@@ -14,6 +14,7 @@
     <logger name="controllers.actions.MessageTransformer" level="${logger.MessageTransformer:-ERROR}"/>
     <logger name="controllers.actions.ValidateInboundMessageAction" level="${logger.ValidateInboundMessageAction:-WARN}"/>
     <logger name="controllers.actions.ValidateOutboundMessageAction" level="${logger.ValidateOutboundMessageAction:-WARN}"/>
+    <logger name="migrations.MigrationRunner" level="${logger.MigrationRunner:-INFO}"/>
 
     <logger name="application.workers.AddJsonToMessagesWorker" level="${logger.application.workers.AddJsonToMessagesWorker:-INFO}"/>
 

--- a/it/api/OutboundMessagesApiSpec.scala
+++ b/it/api/OutboundMessagesApiSpec.scala
@@ -16,63 +16,50 @@
 
 package api
 
-import cats.syntax.all._
 import cats.data.NonEmptyList
-
-import play.api.test.Helpers._
+import cats.syntax.all._
 import generators.ModelGenerators
-import models.ArrivalStatus.UnloadingPermission
 import models.Arrival
+import models.ArrivalStatus.UnloadingPermission
+import models.MessageId
 import models.MessageStatus
 import models.MessageType
 import models.MovementMessageWithStatus
 import models.MovementMessageWithoutStatus
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalatest.BeforeAndAfterEach
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.OptionValues
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import org.scalatest.EitherValues
-import org.scalatest.OptionValues
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import play.api.Application
 import play.api.libs.json.JsNumber
 import play.api.libs.ws.WSClient
 import play.api.test.DefaultAwaitTimeout
 import play.api.test.FutureAwaits
+import play.api.test.Helpers._
 import repositories.ArrivalMovementRepository
 import utils.Format
 
 import java.net.URLEncoder
-import java.time.ZoneOffset
-import java.time.OffsetDateTime
 import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
-
 import scala.concurrent.ExecutionContext.Implicits.global
-import models.MessageId
 
 class OutboundMessagesApiSpec
     extends AnyFreeSpec
     with GuiceOneServerPerSuite
     with Matchers
-    with ScalaCheckPropertyChecks
     with ModelGenerators
     with OptionValues
-    with EitherValues
     with FutureAwaits
     with DefaultAwaitTimeout
-    with ScalaFutures
-    with WiremockSuite
-    with BeforeAndAfterEach {
+    with WiremockSuite {
 
   override protected def portConfigKeys: Seq[String] = Seq(
     "microservice.services.auth.port",
     "microservice.services.eis.port"
   )
-
-  implicit override lazy val app: Application = appBuilder.build()
 
   lazy val ws: WSClient                    = app.injector.instanceOf[WSClient]
   lazy val repo: ArrivalMovementRepository = app.injector.instanceOf[ArrivalMovementRepository]

--- a/it/api/OutboundMessagesApiSpec.scala
+++ b/it/api/OutboundMessagesApiSpec.scala
@@ -51,6 +51,7 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import models.MessageId
 
 class OutboundMessagesApiSpec
     extends AnyFreeSpec
@@ -80,8 +81,8 @@ class OutboundMessagesApiSpec
     "return a Bad request if a second request comes in for the same unloading remarks" in {
 
       val movements = NonEmptyList(
-        MovementMessageWithStatus(LocalDateTime.now(), MessageType.ArrivalNotification, <CC007A></CC007A>, MessageStatus.SubmissionSucceeded, 1),
-        MovementMessageWithoutStatus(LocalDateTime.now(), MessageType.UnloadingPermission, <CC043A></CC043A>, 1) :: Nil
+        MovementMessageWithStatus(MessageId(1), LocalDateTime.now(), MessageType.ArrivalNotification, <CC007A></CC007A>, MessageStatus.SubmissionSucceeded, 1),
+        MovementMessageWithoutStatus(MessageId(2), LocalDateTime.now(), MessageType.UnloadingPermission, <CC043A></CC043A>, 1) :: Nil
       )
 
       val arrival =

--- a/it/api/WiremockSuite.scala
+++ b/it/api/WiremockSuite.scala
@@ -17,12 +17,16 @@
 package api
 
 import com.github.tomakehurst.wiremock.WireMockServer
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
-import play.api.inject.guice.{GuiceApplicationBuilder, GuiceableModule}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.Suite
+import org.scalatestplus.play.ServerProvider
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.inject.guice.GuiceableModule
+import play.api.Application
 
 trait WiremockSuite extends BeforeAndAfterAll with BeforeAndAfterEach {
-  this: Suite =>
+  this: Suite with ServerProvider =>
 
   protected val server: WireMockServer = new WireMockServer(11111)
 
@@ -31,10 +35,13 @@ trait WiremockSuite extends BeforeAndAfterAll with BeforeAndAfterEach {
   protected lazy val appBuilder: GuiceApplicationBuilder =
     new GuiceApplicationBuilder()
       .configure(
-        portConfigKeys.map(key => key -> server.port().toString): _*
-
-     )
+        portConfigKeys.map(
+          key => key -> server.port().toString
+        ): _*
+      )
       .overrides(bindings: _*)
+
+  override lazy val app: Application = appBuilder.build()
 
   protected def bindings: Seq[GuiceableModule] = Seq.empty
 

--- a/it/base/ItSpecBase.scala
+++ b/it/base/ItSpecBase.scala
@@ -31,6 +31,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import play.api.inject.guice.GuiceApplicationBuilder
+import models.MessageId
 
 class ItSpecBase
     extends AnyFreeSpec
@@ -45,6 +46,6 @@ class ItSpecBase
   val arrivalWithOneMessage: Gen[Arrival] = for {
     arrival         <- arbitrary[Arrival]
     movementMessage <- arbitrary[MovementMessageWithStatus]
-  } yield arrival.copy(messages = NonEmptyList.one(movementMessage.copy(status = SubmissionPending)))
+  } yield arrival.copy(messages = NonEmptyList.one(movementMessage.copy(messageId = MessageId(1), status = SubmissionPending)))
 
 }

--- a/it/repositories/LockRepositorySpec.scala
+++ b/it/repositories/LockRepositorySpec.scala
@@ -29,7 +29,7 @@ import reactivemongo.play.json.collection.JSONCollection
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class LockRepositorySpec extends ItSpecBase with FailOnUnindexedQueries with ScalaCheckPropertyChecks {
+class LockRepositorySpec extends ItSpecBase with MongoSuite with ScalaCheckPropertyChecks {
 
   "lock" - {
     "must lock an arrivalId when it is not already locked" in {

--- a/it/repositories/WorkerLockRepositorySpec.scala
+++ b/it/repositories/WorkerLockRepositorySpec.scala
@@ -30,7 +30,7 @@ import reactivemongo.play.json.collection.JSONCollection
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class WorkerLockRepositorySpec extends ItSpecBase with FailOnUnindexedQueries with ScalaCheckPropertyChecks {
+class WorkerLockRepositorySpec extends ItSpecBase with MongoSuite with ScalaCheckPropertyChecks {
 
   "lock" - {
     "must lock an id when it is not already locked" in {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,31 +3,36 @@ import sbt._
 
 object AppDependencies {
 
-  private val catsVersion = "2.5.0"
+  private val catsVersion    = "2.5.0"
+  private val mongockVersion = "4.3.8"
 
   val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"       %% "bootstrap-backend-play-27"       % "3.4.0",
-    "org.reactivemongo" %% "play2-reactivemongo"             % "0.20.11-play27",
-    "org.reactivemongo" %% "reactivemongo-akkastream"        % "0.20.11",
-    "com.typesafe.play" %% "play-iteratees"                  % "2.6.1",
-    "com.typesafe.play" %% "play-iteratees-reactive-streams" % "2.6.1",
-    "org.typelevel"     %% "cats-core"                       % catsVersion,
-    "org.json"          % "json"                             % "20200518"
+    "uk.gov.hmrc"                  %% "bootstrap-backend-play-27"       % "3.4.0",
+    "org.reactivemongo"            %% "play2-reactivemongo"             % "0.20.11-play27",
+    "org.reactivemongo"            %% "reactivemongo-akkastream"        % "0.20.11",
+    "com.typesafe.play"            %% "play-iteratees"                  % "2.6.1",
+    "com.typesafe.play"            %% "play-iteratees-reactive-streams" % "2.6.1",
+    "org.typelevel"                %% "cats-core"                       % catsVersion,
+    "org.json"                      % "json"                            % "20200518",
+    "com.github.cloudyrock.mongock" % "mongock-standalone"              % mongockVersion,
+    "com.github.cloudyrock.mongock" % "mongodb-sync-v4-driver"          % mongockVersion,
+    "org.mongodb"                   % "mongodb-driver-sync"             % "4.0.5",
+    "uk.gov.hmrc.mongo"            %% "hmrc-mongo-play-27"              % "0.51.0"
   )
 
   val test: Seq[ModuleID] = Seq(
-    "org.mockito"            % "mockito-core"          % "3.3.3",
+    "org.mockito"             % "mockito-core"         % "3.3.3",
     "org.scalatest"          %% "scalatest"            % "3.2.8",
     "com.typesafe.play"      %% "play-test"            % current,
-    "org.pegdown"            % "pegdown"               % "1.6.0",
+    "org.pegdown"             % "pegdown"              % "1.6.0",
     "org.scalatestplus.play" %% "scalatestplus-play"   % "4.0.3",
     "org.scalatestplus"      %% "mockito-3-2"          % "3.1.2.0",
     "org.scalacheck"         %% "scalacheck"           % "1.14.3",
-    "com.github.tomakehurst" % "wiremock-standalone"   % "2.27.2",
+    "com.github.tomakehurst"  % "wiremock-standalone"  % "2.27.2",
     "org.typelevel"          %% "cats-laws"            % catsVersion,
     "org.typelevel"          %% "discipline-core"      % "1.1.4",
     "org.typelevel"          %% "discipline-scalatest" % "2.1.4",
-    "com.vladsch.flexmark"   % "flexmark-all"          % "0.35.10",
+    "com.vladsch.flexmark"    % "flexmark-all"         % "0.35.10",
     "com.typesafe.akka"      %% "akka-stream-testkit"  % "2.5.31"
   ).map(_ % "test, it")
 }

--- a/test/audit/AuditServiceSpec.scala
+++ b/test/audit/AuditServiceSpec.scala
@@ -47,7 +47,8 @@ class AuditServiceSpec extends SpecBase with ScalaCheckPropertyChecks with Befor
       val requestXml         = <xml>test</xml>
       val requestedXmlToJson = Json.parse("{\"channel\":\"api\",\"xml\":\"test\"}")
 
-      val movementMessage = MovementMessageWithStatus(LocalDateTime.now, MessageType.ArrivalNotification, requestXml, MessageStatus.SubmissionSucceeded, 1)
+      val movementMessage =
+        MovementMessageWithStatus(MessageId(1), LocalDateTime.now, MessageType.ArrivalNotification, requestXml, MessageStatus.SubmissionSucceeded, 1)
 
       val auditType = "Some AuditEvent"
 
@@ -66,7 +67,7 @@ class AuditServiceSpec extends SpecBase with ScalaCheckPropertyChecks with Befor
       val requestXml         = <xml>test</xml>
       val requestedXmlToJson = Json.parse("{\"channel\":\"api\",\"xml\":\"test\"}")
 
-      val movementMessage = MovementMessageWithoutStatus(LocalDateTime.now, MessageType.GoodsReleased, requestXml, 1)
+      val movementMessage = MovementMessageWithoutStatus(MessageId(1), LocalDateTime.now, MessageType.GoodsReleased, requestXml, 1)
 
       val application = baseApplicationBuilder
         .overrides(bind[AuditConnector].toInstance(mockAuditConnector))
@@ -85,7 +86,7 @@ class AuditServiceSpec extends SpecBase with ScalaCheckPropertyChecks with Befor
       val requestXml         = <xml>test</xml>
       val requestedXmlToJson = Json.parse("{\"channel\":\"api\",\"xml\":\"test\"}")
 
-      val movementMessage = MovementMessageWithoutStatus(LocalDateTime.now, MessageType.ArrivalRejection, requestXml, 1)
+      val movementMessage = MovementMessageWithoutStatus(MessageId(1), LocalDateTime.now, MessageType.ArrivalRejection, requestXml, 1)
 
       val application = baseApplicationBuilder
         .overrides(bind[AuditConnector].toInstance(mockAuditConnector))
@@ -104,7 +105,7 @@ class AuditServiceSpec extends SpecBase with ScalaCheckPropertyChecks with Befor
       val requestXml         = <xml>test</xml>
       val requestedXmlToJson = Json.parse("{\"channel\":\"api\",\"xml\":\"test\"}")
 
-      val movementMessage = MovementMessageWithoutStatus(LocalDateTime.now, MessageType.UnloadingPermission, requestXml, 1)
+      val movementMessage = MovementMessageWithoutStatus(MessageId(1), LocalDateTime.now, MessageType.UnloadingPermission, requestXml, 1)
 
       val application = baseApplicationBuilder
         .overrides(bind[AuditConnector].toInstance(mockAuditConnector))
@@ -124,7 +125,7 @@ class AuditServiceSpec extends SpecBase with ScalaCheckPropertyChecks with Befor
       val requestXml         = <xml>test</xml>
       val requestedXmlToJson = Json.parse("{\"channel\":\"api\",\"xml\":\"test\"}")
 
-      val movementMessage = MovementMessageWithoutStatus(LocalDateTime.now, MessageType.UnloadingRemarksRejection, requestXml, 1)
+      val movementMessage = MovementMessageWithoutStatus(MessageId(1), LocalDateTime.now, MessageType.UnloadingRemarksRejection, requestXml, 1)
 
       val application = baseApplicationBuilder
         .overrides(bind[AuditConnector].toInstance(mockAuditConnector))

--- a/test/connectors/MessageConnectorSpec.scala
+++ b/test/connectors/MessageConnectorSpec.scala
@@ -41,6 +41,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.test.Helpers.running
 import uk.gov.hmrc.http.HeaderCarrier
+import models.MessageId
 
 class MessageConnectorSpec
     extends AnyFreeSpec
@@ -85,7 +86,7 @@ class MessageConnectorSpec
             )
         )
 
-        val postValue = MovementMessageWithStatus(LocalDateTime.now(), messageType, <CC007A>test</CC007A>, MessageStatus.SubmissionPending, 1)
+        val postValue = MovementMessageWithStatus(MessageId(1), LocalDateTime.now(), messageType, <CC007A>test</CC007A>, MessageStatus.SubmissionPending, 1)
         val arrivalId = ArrivalId(123)
 
         val app = appBuilder.build()
@@ -114,7 +115,7 @@ class MessageConnectorSpec
             )
         )
 
-        val postValue = MovementMessageWithStatus(LocalDateTime.now(), messageType, <CC007A>test</CC007A>, MessageStatus.SubmissionPending, 1)
+        val postValue = MovementMessageWithStatus(MessageId(1), LocalDateTime.now(), messageType, <CC007A>test</CC007A>, MessageStatus.SubmissionPending, 1)
         val arrivalId = ArrivalId(123)
 
         val app = appBuilder.build()
@@ -143,7 +144,7 @@ class MessageConnectorSpec
             )
         )
 
-        val postValue = MovementMessageWithStatus(LocalDateTime.now(), messageType, <CC007A>test</CC007A>, MessageStatus.SubmissionPending, 1)
+        val postValue = MovementMessageWithStatus(MessageId(1), LocalDateTime.now(), messageType, <CC007A>test</CC007A>, MessageStatus.SubmissionPending, 1)
         val arrivalId = ArrivalId(123)
 
         val app = appBuilder.build()
@@ -172,7 +173,7 @@ class MessageConnectorSpec
             )
         )
 
-        val postValue = MovementMessageWithStatus(LocalDateTime.now(), messageType, <CC007A>test</CC007A>, MessageStatus.SubmissionPending, 1)
+        val postValue = MovementMessageWithStatus(MessageId(1), LocalDateTime.now(), messageType, <CC007A>test</CC007A>, MessageStatus.SubmissionPending, 1)
         val arrivalId = ArrivalId(123)
 
         val app = appBuilder.build()
@@ -201,7 +202,7 @@ class MessageConnectorSpec
             )
         )
 
-        val postValue = MovementMessageWithStatus(LocalDateTime.now(), messageType, <CC007A>test</CC007A>, MessageStatus.SubmissionPending, 1)
+        val postValue = MovementMessageWithStatus(MessageId(1), LocalDateTime.now(), messageType, <CC007A>test</CC007A>, MessageStatus.SubmissionPending, 1)
         val arrivalId = ArrivalId(123)
 
         val app = appBuilder.build()
@@ -230,7 +231,7 @@ class MessageConnectorSpec
             )
         )
 
-        val postValue = MovementMessageWithStatus(LocalDateTime.now(), messageType, <CC007A>test</CC007A>, MessageStatus.SubmissionPending, 1)
+        val postValue = MovementMessageWithStatus(MessageId(1), LocalDateTime.now(), messageType, <CC007A>test</CC007A>, MessageStatus.SubmissionPending, 1)
         val arrivalId = ArrivalId(123)
 
         val app = appBuilder.build()

--- a/test/connectors/PushPullNotificationConnectorSpec.scala
+++ b/test/connectors/PushPullNotificationConnectorSpec.scala
@@ -130,12 +130,8 @@ class PushPullNotificationConnectorSpec extends AnyFreeSpec with WiremockSuite w
       val testBoxId      = "1c5b9365-18a6-55a5-99c9-83a091ac7f26"
       val testArrivalId  = ArrivalId(1)
       val testMessageUri = requestId(testArrivalId) + "/messages" + ""
-      val testNotification = ArrivalMessageNotification(testMessageUri,
-                                                        requestId(testArrivalId),
-                                                        testArrivalId,
-                                                        MessageId.fromIndex(1),
-                                                        LocalDateTime.now,
-                                                        MessageType.UnloadingPermission)
+      val testNotification =
+        ArrivalMessageNotification(testMessageUri, requestId(testArrivalId), testArrivalId, MessageId(1), LocalDateTime.now, MessageType.UnloadingPermission)
 
       val testUrlPath = s"/box/$testBoxId/notifications"
 

--- a/test/controllers/MovementsControllerSpec.scala
+++ b/test/controllers/MovementsControllerSpec.scala
@@ -110,6 +110,7 @@ class MovementsControllerSpec extends SpecBase with ScalaCheckPropertyChecks wit
     </CC007A>
 
   def movementMessage(messageCorrelationId: Int): MovementMessageWithStatus = MovementMessageWithStatus(
+    MessageId(1),
     localDateTime,
     MessageType.ArrivalNotification,
     savedXmlMessage(messageCorrelationId).map(trim),
@@ -536,7 +537,7 @@ class MovementsControllerSpec extends SpecBase with ScalaCheckPropertyChecks wit
             header("Location", result).value must be(routes.MovementsController.getArrival(initializedArrival.arrivalId).url)
             verify(mockSubmitMessageService, times(1)).submitMessage(
               eqTo(initializedArrival.arrivalId),
-              eqTo(MessageId.fromIndex(1)),
+              eqTo(MessageId(2)),
               captor.capture(),
               eqTo(ArrivalStatus.ArrivalSubmitted),
               any()
@@ -816,7 +817,7 @@ class MovementsControllerSpec extends SpecBase with ScalaCheckPropertyChecks wit
           header("Location", result).value must be(routes.MovementsController.getArrival(initializedArrival.arrivalId).url)
           verify(mockSubmitMessageService, times(1)).submitIe007Message(
             eqTo(initializedArrival.arrivalId),
-            eqTo(MessageId.fromIndex(1)),
+            eqTo(MessageId(2)),
             captor.capture(),
             eqTo(initializedArrival.movementReferenceNumber),
             any()

--- a/test/controllers/NCTSMessageControllerSpec.scala
+++ b/test/controllers/NCTSMessageControllerSpec.scala
@@ -88,7 +88,7 @@ class NCTSMessageControllerSpec extends SpecBase with ScalaCheckPropertyChecks w
       "must return OK, when the service validates and save the message" in {
 
         when(mockArrivalMovementRepository.get(any())).thenReturn(Future.successful(Some(arrivalWithoutBox)))
-        when(mockSaveMessageService.validateXmlAndSaveMessage(any(), any(), any(), any(), any())(any()))
+        when(mockSaveMessageService.validateXmlAndSaveMessage(any(), any(), any(), any(), any(), any())(any()))
           .thenReturn(Future.successful(SubmissionProcessingResult.SubmissionSuccess))
         when(mockLockRepository.lock(any())).thenReturn(Future.successful(true))
         when(mockLockRepository.unlock(any())).thenReturn(Future.successful(true))
@@ -142,7 +142,7 @@ class NCTSMessageControllerSpec extends SpecBase with ScalaCheckPropertyChecks w
 
       "must lock, return Internal Server Error and unlock if adding the message to the movement fails" in {
         when(mockArrivalMovementRepository.get(any())).thenReturn(Future.successful(Some(arrivalWithoutBox)))
-        when(mockSaveMessageService.validateXmlAndSaveMessage(any(), any(), any(), any(), any())(any()))
+        when(mockSaveMessageService.validateXmlAndSaveMessage(any(), any(), any(), any(), any(), any())(any()))
           .thenReturn(Future.successful(SubmissionProcessingResult.SubmissionFailureInternal))
         when(mockLockRepository.lock(any())).thenReturn(Future.successful(true))
         when(mockLockRepository.unlock(any())).thenReturn(Future.successful(true))
@@ -192,14 +192,14 @@ class NCTSMessageControllerSpec extends SpecBase with ScalaCheckPropertyChecks w
 
           status(result) mustEqual BAD_REQUEST
           verify(mockLockRepository, times(1)).lock(arrivalId)
-          verify(mockSaveMessageService, never()).validateXmlAndSaveMessage(any(), any(), any(), any(), any())(any())
+          verify(mockSaveMessageService, never()).validateXmlAndSaveMessage(any(), any(), any(), any(), any(), any())(any())
           verify(mockLockRepository, times(1)).unlock(arrivalId)
         }
       }
 
       "must lock the arrivalWithoutBox, return BadRequest error and unlock when fail to validate message" in {
         when(mockArrivalMovementRepository.get(any())).thenReturn(Future.successful(Some(arrivalWithoutBox)))
-        when(mockSaveMessageService.validateXmlAndSaveMessage(any(), any(), any(), any(), any())(any()))
+        when(mockSaveMessageService.validateXmlAndSaveMessage(any(), any(), any(), any(), any(), any())(any()))
           .thenReturn(Future.successful(SubmissionProcessingResult.SubmissionFailureExternal))
         when(mockLockRepository.lock(any())).thenReturn(Future.successful(true))
         when(mockLockRepository.unlock(any())).thenReturn(Future.successful(true))
@@ -222,14 +222,14 @@ class NCTSMessageControllerSpec extends SpecBase with ScalaCheckPropertyChecks w
 
           status(result) mustEqual BAD_REQUEST
           verify(mockLockRepository, times(1)).lock(arrivalId)
-          verify(mockSaveMessageService, times(1)).validateXmlAndSaveMessage(any(), any(), any(), any(), any())(any())
+          verify(mockSaveMessageService, times(1)).validateXmlAndSaveMessage(any(), any(), any(), any(), any(), any())(any())
           verify(mockLockRepository, times(1)).unlock(arrivalId)
         }
       }
 
       "must not send push notification when there is no notificationBox present" in {
         when(mockArrivalMovementRepository.get(any())).thenReturn(Future.successful(Some(arrivalWithoutBox)))
-        when(mockSaveMessageService.validateXmlAndSaveMessage(any(), any(), any(), any(), any())(any()))
+        when(mockSaveMessageService.validateXmlAndSaveMessage(any(), any(), any(), any(), any(), any())(any()))
           .thenReturn(Future.successful(SubmissionProcessingResult.SubmissionSuccess))
         when(mockLockRepository.lock(any())).thenReturn(Future.successful(true))
         when(mockLockRepository.unlock(any())).thenReturn(Future.successful(true))
@@ -260,7 +260,7 @@ class NCTSMessageControllerSpec extends SpecBase with ScalaCheckPropertyChecks w
         def boxIdMatcher = refEq(testBoxId).asInstanceOf[BoxId]
 
         when(mockArrivalMovementRepository.get(any())).thenReturn(Future.successful(Some(arrivalWithBox)))
-        when(mockSaveMessageService.validateXmlAndSaveMessage(any(), any(), any(), any(), any())(any()))
+        when(mockSaveMessageService.validateXmlAndSaveMessage(any(), any(), any(), any(), any(), any())(any()))
           .thenReturn(Future.successful(SubmissionProcessingResult.SubmissionSuccess))
         when(mockLockRepository.lock(any())).thenReturn(Future.successful(true))
         when(mockLockRepository.unlock(any())).thenReturn(Future.successful(true))
@@ -292,7 +292,7 @@ class NCTSMessageControllerSpec extends SpecBase with ScalaCheckPropertyChecks w
         def boxIdMatcher = refEq(testBoxId).asInstanceOf[BoxId]
 
         when(mockArrivalMovementRepository.get(any())).thenReturn(Future.successful(Some(arrivalWithBox)))
-        when(mockSaveMessageService.validateXmlAndSaveMessage(any(), any(), any(), any(), any())(any()))
+        when(mockSaveMessageService.validateXmlAndSaveMessage(any(), any(), any(), any(), any(), any())(any()))
           .thenReturn(Future.successful(SubmissionProcessingResult.SubmissionSuccess))
         when(mockLockRepository.lock(any())).thenReturn(Future.successful(true))
         when(mockLockRepository.unlock(any())).thenReturn(Future.successful(true))

--- a/test/generators/ModelGenerators.scala
+++ b/test/generators/ModelGenerators.scala
@@ -106,40 +106,39 @@ trait ModelGenerators extends BaseGenerators with JavaTimeGenerators {
       Gen.oneOf(MessageStatus.values)
     }
 
-  implicit lazy val arbitraryMessageWithStateXml: Arbitrary[MovementMessageWithStatus] = {
+  implicit lazy val arbitraryMessageWithStateXml: Arbitrary[MovementMessageWithStatus] =
     Arbitrary {
       for {
+        messageId   <- arbitrary[MessageId]
         dateTime    <- arbitrary[LocalDateTime]
         xml         <- Gen.const(<blankXml>message</blankXml>)
         messageType <- Gen.oneOf(MessageType.values)
         status = MessageStatus.SubmissionPending
-      } yield MovementMessageWithStatus(dateTime, messageType, xml, status, 1)
+      } yield MovementMessageWithStatus(messageId, dateTime, messageType, xml, status, 1)
     }
-  }
 
-  implicit lazy val arbitraryMessageWithoutStateXml: Arbitrary[MovementMessageWithoutStatus] = {
+  implicit lazy val arbitraryMessageWithoutStateXml: Arbitrary[MovementMessageWithoutStatus] =
     Arbitrary {
       for {
+        messageId   <- arbitrary[MessageId]
         date        <- datesBetween(pastDate, dateNow)
         time        <- timesBetween(pastDate, dateNow)
         xml         <- Gen.const(<blankXml>message</blankXml>)
         messageType <- Gen.oneOf(MessageType.values)
-      } yield MovementMessageWithoutStatus(LocalDateTime.of(date, time), messageType, xml, 1)
+      } yield MovementMessageWithoutStatus(messageId, LocalDateTime.of(date, time), messageType, xml, 1)
     }
-  }
 
   implicit lazy val arbitraryMovementMessage: Arbitrary[MovementMessage] =
     Arbitrary {
       Gen.oneOf(arbitrary[MovementMessageWithoutStatus], arbitrary[MovementMessageWithStatus])
     }
 
-  implicit lazy val arbitraryArrivalId: Arbitrary[ArrivalId] = {
+  implicit lazy val arbitraryArrivalId: Arbitrary[ArrivalId] =
     Arbitrary {
       for {
         id <- intWithMaxLength(9)
       } yield ArrivalId(id)
     }
-  }
 
   implicit lazy val arbitraryState: Arbitrary[ArrivalStatus] =
     Arbitrary {
@@ -151,7 +150,7 @@ trait ModelGenerators extends BaseGenerators with JavaTimeGenerators {
       Gen.oneOf(ChannelType.values)
     }
 
-  implicit lazy val arbitraryArrival: Arbitrary[Arrival] = {
+  implicit lazy val arbitraryArrival: Arbitrary[Arrival] =
     Arbitrary {
       for {
         arrivalId               <- arbitrary[ArrivalId]
@@ -177,9 +176,8 @@ trait ModelGenerators extends BaseGenerators with JavaTimeGenerators {
           notificationBox = None
         )
     }
-  }
 
-  val genArrivalWithSuccessfulArrival: Gen[Arrival] = {
+  val genArrivalWithSuccessfulArrival: Gen[Arrival] =
     Arbitrary {
       for {
         message <- Arbitrary.arbitrary[MovementMessageWithStatus]
@@ -189,12 +187,15 @@ trait ModelGenerators extends BaseGenerators with JavaTimeGenerators {
         arrival.copy(messages = NonEmptyList.one(successfulMessage), eoriNumber = "eori")
       }
     }.arbitrary
-  }
 
   implicit lazy val arbitraryMovementReferenceNumber: Arbitrary[MovementReferenceNumber] =
     Arbitrary {
       for {
-        year    <- Gen.choose(0, 99).map(y => f"$y%02d")
+        year <- Gen
+          .choose(0, 99)
+          .map(
+            y => f"$y%02d"
+          )
         country <- Gen.pick(2, 'A' to 'Z')
         serial  <- Gen.pick(13, ('A' to 'Z') ++ ('0' to '9'))
       } yield MovementReferenceNumber(year ++ country.mkString ++ serial.mkString)
@@ -222,7 +223,7 @@ trait ModelGenerators extends BaseGenerators with JavaTimeGenerators {
 
   implicit lazy val arbitraryMessageId: Arbitrary[MessageId] =
     Arbitrary {
-      intsAboveValue(0).map(MessageId.fromIndex)
+      intsAboveValue(0).map(MessageId.apply)
     }
 
   implicit lazy val arbitraryFailure: Arbitrary[SubmissionProcessingResult.SubmissionFailure] =
@@ -233,7 +234,7 @@ trait ModelGenerators extends BaseGenerators with JavaTimeGenerators {
       )
     )
 
-  implicit lazy val arbitraryResponseMovementMessage: Arbitrary[ResponseMovementMessage] = {
+  implicit lazy val arbitraryResponseMovementMessage: Arbitrary[ResponseMovementMessage] =
     Arbitrary {
       for {
         location    <- arbitrary[String]
@@ -242,7 +243,6 @@ trait ModelGenerators extends BaseGenerators with JavaTimeGenerators {
         message     <- Gen.const(<blankXml>message</blankXml>)
       } yield ResponseMovementMessage(location, dateTime, messageType, message)
     }
-  }
 
   implicit lazy val arbitrarySubmissionFailure: Arbitrary[EisSubmissionFailure] =
     Arbitrary(Gen.oneOf(arbitrary[EisSubmissionRejected], arbitrary[EisSubmissionFailureDownstream]))

--- a/test/migrations/MovementsChangeLogSpec.scala
+++ b/test/migrations/MovementsChangeLogSpec.scala
@@ -57,7 +57,7 @@ class MovementsChangeLogSpec extends SpecBase with IntegrationPatience with Befo
 
     val mongo = app.injector.instanceOf[ReactiveMongoApi]
 
-    val insertDepartures = for {
+    val insertArrivals = for {
       db <- mongo.database
 
       _ <- db.drop()
@@ -102,7 +102,7 @@ class MovementsChangeLogSpec extends SpecBase with IntegrationPatience with Befo
       }
     } yield ()
 
-    insertDepartures.futureValue
+    insertArrivals.futureValue
   }
 
   "MovementsChangeLog" - {

--- a/test/migrations/MovementsChangeLogSpec.scala
+++ b/test/migrations/MovementsChangeLogSpec.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package migrations
+
+import base.SpecBase
+import cats.syntax.all._
+import models.ArrivalId
+import models.ArrivalStatus
+import models.ChannelType
+import models.MessageStatus
+import models.MessageType
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.IntegrationPatience
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.libs.json.Json
+import play.modules.reactivemongo.ReactiveMongoApi
+import reactivemongo.play.json._
+import reactivemongo.play.json.collection.JSONCollection
+import repositories.ArrivalMovementRepository
+
+import java.time.LocalDateTime
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Random
+
+class MovementsChangeLogSpec extends SpecBase with IntegrationPatience with BeforeAndAfterAll with GuiceOneAppPerSuite {
+  val arrivalIds = (1 to 20).map(ArrivalId.apply)
+  val eori       = "123456789000"
+
+  override protected def afterAll(): Unit = {
+    val mongo = app.injector.instanceOf[ReactiveMongoApi]
+
+    val dropDatabase = for {
+      db <- mongo.database
+      _  <- db.drop()
+    } yield ()
+
+    dropDatabase.futureValue
+  }
+
+  override def beforeAll(): Unit = {
+    import models.MongoDateTimeFormats._
+    import utils.NodeSeqFormat._
+
+    val mongo = app.injector.instanceOf[ReactiveMongoApi]
+
+    val insertDepartures = for {
+      db <- mongo.database
+
+      _ <- db.drop()
+
+      coll = db.collection[JSONCollection](ArrivalMovementRepository.collectionName)
+
+      _ <- coll.insert.many {
+        for (id <- arrivalIds)
+          yield
+            Json.obj(
+              "_id"                      -> id.index,
+              "channel"                  -> ChannelType.web.toString,
+              "eoriNumber"               -> eori,
+              "movementReferenceNumber"  -> Random.alphanumeric.take(20).mkString,
+              "status"                   -> ArrivalStatus.ArrivalSubmitted.toString,
+              "created"                  -> LocalDateTime.of(2021, 7, 15, 12, 12),
+              "updated"                  -> LocalDateTime.of(2021, 7, 15, 12, 13),
+              "lastUpdated"              -> LocalDateTime.of(2021, 7, 15, 12, 13),
+              "nextMessageCorrelationId" -> 2,
+              "messages" -> Json.arr(
+                Json.obj(
+                  "dateTime"             -> LocalDateTime.of(2021, 7, 15, 12, 12),
+                  "messageType"          -> MessageType.ArrivalNotification.toString,
+                  "message"              -> <CC007A></CC007A>,
+                  "status"               -> MessageStatus.SubmissionSucceeded.toString,
+                  "messageCorrelationId" -> 1
+                ),
+                Json.obj(
+                  "dateTime"             -> LocalDateTime.of(2021, 7, 15, 12, 12),
+                  "messageType"          -> MessageType.UnloadingPermission.toString,
+                  "message"              -> <CC043A></CC043A>,
+                  "messageCorrelationId" -> 1
+                ),
+                Json.obj(
+                  "dateTime"             -> LocalDateTime.of(2021, 7, 15, 12, 13),
+                  "messageType"          -> MessageType.UnloadingRemarks.toString,
+                  "message"              -> <CC044A></CC044A>,
+                  "messageCorrelationId" -> 1
+                )
+              )
+            )
+      }
+    } yield ()
+
+    insertDepartures.futureValue
+  }
+
+  "MovementsChangeLog" - {
+    "addMessageIdToMessages" - {
+      "should add message ID to messages in the arrivals collection" in {
+        val repo   = app.injector.instanceOf[ArrivalMovementRepository]
+        val runner = app.injector.instanceOf[MigrationRunner]
+
+        runner.runMigrations().futureValue
+
+        arrivalIds.foreach {
+          arrivalId =>
+            val arrival = repo.get(arrivalId).futureValue.value
+            arrival.messages.mapWithIndex {
+              case (message, index) =>
+                message.messageId.index mustBe (index + 1)
+            }
+        }
+      }
+    }
+  }
+}

--- a/test/migrations/MovementsChangeLogSpec.scala
+++ b/test/migrations/MovementsChangeLogSpec.scala
@@ -118,7 +118,7 @@ class MovementsChangeLogSpec extends SpecBase with IntegrationPatience with Befo
             val arrival = repo.get(arrivalId).futureValue.value
             arrival.messages.mapWithIndex {
               case (message, index) =>
-                message.messageId.index mustBe (index + 1)
+                message.messageId.value mustBe (index + 1)
             }
         }
       }

--- a/test/models/ArrivalMessageNotificationSpec.scala
+++ b/test/models/ArrivalMessageNotificationSpec.scala
@@ -53,7 +53,7 @@ class ArrivalMessageNotificationSpec extends SpecBase with ScalaCheckDrivenPrope
           s"/customs/transits/movements/arrivals/${arrival.arrivalId.index}/messages/${arrival.messages.length + 1}",
           s"/customs/transits/movements/arrivals/${arrival.arrivalId.index}",
           arrival.arrivalId,
-          MessageId.fromIndex(arrival.messages.length),
+          MessageId(arrival.messages.length + 1),
           now,
           response.messageType
         )

--- a/test/models/ArrivalSpec.scala
+++ b/test/models/ArrivalSpec.scala
@@ -37,13 +37,13 @@ class ArrivalSpec extends SpecBase with ScalaCheckDrivenPropertyChecks with Mode
     }
   }
 
-  "messageWithId returns a list with the message and the MessageId whose value is one more than the index" in {
+  "messageWithId returns a list with the message and its corresponding message ID" in {
     forAll(arrivaGenerator) {
       arrival =>
         arrival.messagesWithId.zipWithIndex.toList.foreach {
           case ((message, messageId), index) =>
             message mustEqual arrival.messages.toList(index)
-            (MessageId.unapply(messageId).value - index) mustEqual 1
+            messageId mustEqual message.messageId
         }
     }
   }

--- a/test/models/ArrivalUpdateSpec.scala
+++ b/test/models/ArrivalUpdateSpec.scala
@@ -122,8 +122,8 @@ class ArrivalUpdateSpec
         messageStatusUpdate =>
           val expectedUpdateJson = Json.obj(
             "$set" -> Json.obj(
-              s"messages.${messageStatusUpdate.messageId.index - 1}.status" -> messageStatusUpdate.messageStatus,
-              "lastUpdated"                                                 -> LocalDateTime.now(clock).withSecond(0).withNano(0)
+              s"messages.${messageStatusUpdate.messageId.index}.status" -> messageStatusUpdate.messageStatus,
+              "lastUpdated"                                             -> LocalDateTime.now(clock).withSecond(0).withNano(0)
             )
           )
 
@@ -154,9 +154,9 @@ class ArrivalUpdateSpec
         compoundStatusUpdate =>
           val expectedUpdateJson = Json.obj(
             "$set" -> Json.obj(
-              "status"                                                                           -> compoundStatusUpdate.arrivalStatusUpdate.arrivalStatus,
-              s"messages.${compoundStatusUpdate.messageStatusUpdate.messageId.index - 1}.status" -> compoundStatusUpdate.messageStatusUpdate.messageStatus,
-              "lastUpdated"                                                                      -> LocalDateTime.now(clock).withSecond(0).withNano(0)
+              "status"                                                                       -> compoundStatusUpdate.arrivalStatusUpdate.arrivalStatus,
+              s"messages.${compoundStatusUpdate.messageStatusUpdate.messageId.index}.status" -> compoundStatusUpdate.messageStatusUpdate.messageStatus,
+              "lastUpdated"                                                                  -> LocalDateTime.now(clock).withSecond(0).withNano(0)
             )
           )
 
@@ -169,7 +169,7 @@ class ArrivalUpdateSpec
     " ArrivalModifier returns modify object that would set the MRN, status and the message status" in {
       forAll(arbitrary[ArrivalPutUpdate]) {
         arrivalPutUpdate =>
-          val expectedMessageId = arrivalPutUpdate.arrivalUpdate.messageStatusUpdate.messageId.index - 1
+          val expectedMessageId = arrivalPutUpdate.arrivalUpdate.messageStatusUpdate.messageId.index
           val expectedJson = Json.obj(
             "$set" -> Json.obj(
               "movementReferenceNumber"             -> arrivalPutUpdate.movementReferenceNumber,

--- a/test/models/ArrivalUpdateSpec.scala
+++ b/test/models/ArrivalUpdateSpec.scala
@@ -122,8 +122,8 @@ class ArrivalUpdateSpec
         messageStatusUpdate =>
           val expectedUpdateJson = Json.obj(
             "$set" -> Json.obj(
-              s"messages.${messageStatusUpdate.messageId.index}.status" -> messageStatusUpdate.messageStatus,
-              "lastUpdated"                                             -> LocalDateTime.now(clock).withSecond(0).withNano(0)
+              s"messages.${messageStatusUpdate.messageId.index - 1}.status" -> messageStatusUpdate.messageStatus,
+              "lastUpdated"                                                 -> LocalDateTime.now(clock).withSecond(0).withNano(0)
             )
           )
 
@@ -154,9 +154,9 @@ class ArrivalUpdateSpec
         compoundStatusUpdate =>
           val expectedUpdateJson = Json.obj(
             "$set" -> Json.obj(
-              "status"                                                                       -> compoundStatusUpdate.arrivalStatusUpdate.arrivalStatus,
-              s"messages.${compoundStatusUpdate.messageStatusUpdate.messageId.index}.status" -> compoundStatusUpdate.messageStatusUpdate.messageStatus,
-              "lastUpdated"                                                                  -> LocalDateTime.now(clock).withSecond(0).withNano(0)
+              "status"                                                                           -> compoundStatusUpdate.arrivalStatusUpdate.arrivalStatus,
+              s"messages.${compoundStatusUpdate.messageStatusUpdate.messageId.index - 1}.status" -> compoundStatusUpdate.messageStatusUpdate.messageStatus,
+              "lastUpdated"                                                                      -> LocalDateTime.now(clock).withSecond(0).withNano(0)
             )
           )
 
@@ -169,7 +169,7 @@ class ArrivalUpdateSpec
     " ArrivalModifier returns modify object that would set the MRN, status and the message status" in {
       forAll(arbitrary[ArrivalPutUpdate]) {
         arrivalPutUpdate =>
-          val expectedMessageId = arrivalPutUpdate.arrivalUpdate.messageStatusUpdate.messageId.index
+          val expectedMessageId = arrivalPutUpdate.arrivalUpdate.messageStatusUpdate.messageId.index - 1
           val expectedJson = Json.obj(
             "$set" -> Json.obj(
               "movementReferenceNumber"             -> arrivalPutUpdate.movementReferenceNumber,

--- a/test/models/MessageIdSpec.scala
+++ b/test/models/MessageIdSpec.scala
@@ -34,7 +34,7 @@ class MessageIdSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChe
       forAll(intsAboveValue(0)) {
         value =>
           val result = pathBindable.bind("key", value.toString).value
-          result.index mustEqual value
+          result.value mustEqual value
       }
     }
 

--- a/test/models/MessageIdSpec.scala
+++ b/test/models/MessageIdSpec.scala
@@ -33,11 +33,8 @@ class MessageIdSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChe
     "must bind from a URL for all message id values greater than zero and return the index of the message" in {
       forAll(intsAboveValue(0)) {
         value =>
-          val expectedMessageIndex = value - 1
-
           val result = pathBindable.bind("key", value.toString).value
-
-          result.index mustEqual expectedMessageIndex
+          result.index mustEqual value
       }
     }
 
@@ -51,10 +48,8 @@ class MessageIdSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChe
     "must unbind and convert the index to the message id value" in {
       forAll(intsAboveValue(0)) {
         value =>
-          val messageId            = MessageId.fromIndex(value)
-          val expectedMessageIndex = (value + 1).toString
-
-          pathBindable.unbind("key", messageId) mustEqual expectedMessageIndex
+          val messageId = MessageId(value)
+          pathBindable.unbind("key", messageId) mustEqual value.toString
       }
 
     }

--- a/test/models/MessagesSummarySpec.scala
+++ b/test/models/MessagesSummarySpec.scala
@@ -15,6 +15,7 @@
  */
 
 package models
+
 import generators.ModelGenerators
 import org.scalacheck.Arbitrary
 import org.scalatest.OptionValues
@@ -34,7 +35,7 @@ class MessagesSummarySpec extends AnyFreeSpec with Matchers with ModelGenerators
       val messageId = 1
 
       Json.toJson(
-        MessagesSummary(arrival, MessageId.fromIndex(0), None, None)
+        MessagesSummary(arrival, MessageId(messageId), None, None)
       ) mustBe Json.obj(
         "arrivalId" -> arrival.arrivalId,
         "messages" ->
@@ -51,7 +52,7 @@ class MessagesSummarySpec extends AnyFreeSpec with Matchers with ModelGenerators
       val xmlNegativeMessageId = 2
 
       Json.toJson(
-        MessagesSummary(arrival, MessageId.fromIndex(0), Some(MessageId.fromIndex(1)), None)
+        MessagesSummary(arrival, MessageId(messageId), Some(MessageId(xmlNegativeMessageId)), None)
       ) mustBe Json.obj(
         "arrivalId" -> arrival.arrivalId,
         "messages" ->
@@ -68,7 +69,7 @@ class MessagesSummarySpec extends AnyFreeSpec with Matchers with ModelGenerators
       val rejectionId = 2
 
       Json.toJson(
-        MessagesSummary(arrival = arrival, arrivalNotification = MessageId.fromIndex(0), xmlSubmissionNegativeAcknowledgement = Some(MessageId.fromIndex(1)))
+        MessagesSummary(arrival = arrival, arrivalNotification = MessageId(messageId), xmlSubmissionNegativeAcknowledgement = Some(MessageId(rejectionId)))
       ) mustBe Json.obj(
         "arrivalId" -> arrival.arrivalId,
         "messages" ->
@@ -86,7 +87,7 @@ class MessagesSummarySpec extends AnyFreeSpec with Matchers with ModelGenerators
       val unloadingPermissionId = 3
 
       Json.toJson(
-        MessagesSummary(arrival, MessageId.fromIndex(0), Some(MessageId.fromIndex(1)), Some(MessageId.fromIndex(2)))
+        MessagesSummary(arrival, MessageId(messageId), Some(MessageId(rejectionId)), Some(MessageId(unloadingPermissionId)))
       ) mustBe Json.obj(
         "arrivalId" -> arrival.arrivalId,
         "messages" ->
@@ -107,7 +108,13 @@ class MessagesSummarySpec extends AnyFreeSpec with Matchers with ModelGenerators
       val unloadingRemarksId    = 4
 
       Json.toJson(
-        MessagesSummary(arrival, MessageId.fromIndex(0), Some(MessageId.fromIndex(1)), Some(MessageId.fromIndex(2)), Some(MessageId.fromIndex(3)))
+        MessagesSummary(
+          arrival,
+          MessageId(messageId),
+          Some(MessageId(rejectionId)),
+          Some(MessageId(unloadingPermissionId)),
+          Some(MessageId(unloadingRemarksId))
+        )
       ) mustBe Json.obj(
         "arrivalId" -> arrival.arrivalId,
         "messages" ->
@@ -130,12 +137,14 @@ class MessagesSummarySpec extends AnyFreeSpec with Matchers with ModelGenerators
       val unloadingRemarksRejectionId = 5
 
       Json.toJson(
-        MessagesSummary(arrival,
-                        MessageId.fromIndex(0),
-                        Some(MessageId.fromIndex(1)),
-                        Some(MessageId.fromIndex(2)),
-                        Some(MessageId.fromIndex(3)),
-                        Some(MessageId.fromIndex(4)))
+        MessagesSummary(
+          arrival,
+          MessageId(messageId),
+          Some(MessageId(rejectionId)),
+          Some(MessageId(unloadingPermissionId)),
+          Some(MessageId(unloadingRemarksId)),
+          Some(MessageId(unloadingRemarksRejectionId))
+        )
       ) mustBe Json.obj(
         "arrivalId" -> arrival.arrivalId,
         "messages" ->

--- a/test/models/MovementMessageSpec.scala
+++ b/test/models/MovementMessageSpec.scala
@@ -34,19 +34,19 @@ class MovementMessageSpec extends AnyFreeSpec with Matchers with ScalaCheckPrope
 
       "must create a MovementMessageWithStatus that includes a JSON representation of the XML message" in {
 
-        forAll(arbitrary[LocalDateTime], arbitrary[MessageType], arbitrary[MessageStatus], arbitrary[Int]) {
-          case (dateTime, messageType, status, messageCorrelationId) =>
+        forAll(arbitrary[MessageId], arbitrary[LocalDateTime], arbitrary[MessageType], arbitrary[MessageStatus], arbitrary[Int]) {
+          case (messageId, dateTime, messageType, status, messageCorrelationId) =>
             val xml = <xml><node1>foo</node1><node2>bar</node2></xml>
-            val expectedJson = {
+            val expectedJson =
               Json.obj(
                 "xml" ->
                   Json.obj(
                     "node1" -> "foo",
                     "node2" -> "bar"
-                  ))
-            }
+                  )
+              )
 
-            val model = MovementMessageWithStatus(dateTime, messageType, xml, status, messageCorrelationId)
+            val model = MovementMessageWithStatus(messageId, dateTime, messageType, xml, status, messageCorrelationId)
 
             model.messageJson mustEqual expectedJson
         }
@@ -57,19 +57,20 @@ class MovementMessageSpec extends AnyFreeSpec with Matchers with ScalaCheckPrope
 
       "must succeed when the json contains all of the nodes" in {
 
-        forAll(arbitrary[LocalDateTime], arbitrary[MessageType], arbitrary[MessageStatus], arbitrary[Int]) {
-          case (dateTime, messageType, status, messageCorrelationId) =>
+        forAll(arbitrary[MessageId], arbitrary[LocalDateTime], arbitrary[MessageType], arbitrary[MessageStatus], arbitrary[Int]) {
+          case (messageId, dateTime, messageType, status, messageCorrelationId) =>
             val xml = <xml><node1>foo</node1><node2>bar</node2></xml>
-            val messageJson = {
+            val messageJson =
               Json.obj(
                 "xml" ->
                   Json.obj(
                     "node1" -> "foo",
                     "node2" -> "bar"
-                  ))
-            }
+                  )
+              )
 
             val json = Json.obj(
+              "messageId"            -> Json.toJson(messageId),
               "dateTime"             -> Json.toJson(dateTime)(MongoDateTimeFormats.localDateTimeWrite),
               "messageType"          -> Json.toJson(messageType),
               "message"              -> xml.toString,
@@ -78,7 +79,7 @@ class MovementMessageSpec extends AnyFreeSpec with Matchers with ScalaCheckPrope
               "messageJson"          -> messageJson
             )
 
-            val expectedMovementMessage = MovementMessageWithStatus(dateTime, messageType, xml, status, messageCorrelationId, messageJson)
+            val expectedMovementMessage = MovementMessageWithStatus(messageId, dateTime, messageType, xml, status, messageCorrelationId, messageJson)
 
             json.validate[MovementMessageWithStatus] mustEqual JsSuccess(expectedMovementMessage)
         }
@@ -86,11 +87,12 @@ class MovementMessageSpec extends AnyFreeSpec with Matchers with ScalaCheckPrope
 
       "must succeed when the json does not contain the `messageJson` node, setting that field to an empty Json object" in {
 
-        forAll(arbitrary[LocalDateTime], arbitrary[MessageType], arbitrary[MessageStatus], arbitrary[Int]) {
-          case (dateTime, messageType, status, messageCorrelationId) =>
+        forAll(arbitrary[MessageId], arbitrary[LocalDateTime], arbitrary[MessageType], arbitrary[MessageStatus], arbitrary[Int]) {
+          case (messageId, dateTime, messageType, status, messageCorrelationId) =>
             val xml = <xml><node1>foo</node1><node2>bar</node2></xml>
 
             val json = Json.obj(
+              "messageId"            -> Json.toJson(messageId),
               "dateTime"             -> Json.toJson(dateTime)(MongoDateTimeFormats.localDateTimeWrite),
               "messageType"          -> Json.toJson(messageType),
               "message"              -> xml.toString,
@@ -98,7 +100,7 @@ class MovementMessageSpec extends AnyFreeSpec with Matchers with ScalaCheckPrope
               "messageCorrelationId" -> messageCorrelationId
             )
 
-            val expectedMovementMessage = MovementMessageWithStatus(dateTime, messageType, xml, status, messageCorrelationId, Json.obj())
+            val expectedMovementMessage = MovementMessageWithStatus(messageId, dateTime, messageType, xml, status, messageCorrelationId, Json.obj())
 
             json.validate[MovementMessageWithStatus] mustEqual JsSuccess(expectedMovementMessage)
         }
@@ -112,19 +114,19 @@ class MovementMessageSpec extends AnyFreeSpec with Matchers with ScalaCheckPrope
 
       "must create a MovementMessageWithoutStatus that includes a JSON representation of the XML message" in {
 
-        forAll(arbitrary[LocalDateTime], arbitrary[MessageType], arbitrary[Int]) {
-          case (dateTime, messageType, messageCorrelationId) =>
+        forAll(arbitrary[MessageId], arbitrary[LocalDateTime], arbitrary[MessageType], arbitrary[Int]) {
+          case (messageId, dateTime, messageType, messageCorrelationId) =>
             val xml = <xml><node1>foo</node1><node2>bar</node2></xml>
-            val expectedJson = {
+            val expectedJson =
               Json.obj(
                 "xml" ->
                   Json.obj(
                     "node1" -> "foo",
                     "node2" -> "bar"
-                  ))
-            }
+                  )
+              )
 
-            val model = MovementMessageWithoutStatus(dateTime, messageType, xml, messageCorrelationId)
+            val model = MovementMessageWithoutStatus(messageId, dateTime, messageType, xml, messageCorrelationId)
 
             model.messageJson mustEqual expectedJson
         }
@@ -135,19 +137,20 @@ class MovementMessageSpec extends AnyFreeSpec with Matchers with ScalaCheckPrope
 
       "must succeed when the json contains all of the nodes" in {
 
-        forAll(arbitrary[LocalDateTime], arbitrary[MessageType], arbitrary[Int]) {
-          case (dateTime, messageType, messageCorrelationId) =>
+        forAll(arbitrary[MessageId], arbitrary[LocalDateTime], arbitrary[MessageType], arbitrary[Int]) {
+          case (messageId, dateTime, messageType, messageCorrelationId) =>
             val xml = <xml><node1>foo</node1><node2>bar</node2></xml>
-            val messageJson = {
+            val messageJson =
               Json.obj(
                 "xml" ->
                   Json.obj(
                     "node1" -> "foo",
                     "node2" -> "bar"
-                  ))
-            }
+                  )
+              )
 
             val json = Json.obj(
+              "messageId"            -> Json.toJson(messageId),
               "dateTime"             -> Json.toJson(dateTime)(MongoDateTimeFormats.localDateTimeWrite),
               "messageType"          -> Json.toJson(messageType),
               "message"              -> xml.toString,
@@ -155,7 +158,7 @@ class MovementMessageSpec extends AnyFreeSpec with Matchers with ScalaCheckPrope
               "messageJson"          -> messageJson
             )
 
-            val expectedMovementMessage = MovementMessageWithoutStatus(dateTime, messageType, xml, messageCorrelationId, messageJson)
+            val expectedMovementMessage = MovementMessageWithoutStatus(messageId, dateTime, messageType, xml, messageCorrelationId, messageJson)
 
             json.validate[MovementMessageWithoutStatus] mustEqual JsSuccess(expectedMovementMessage)
         }
@@ -163,18 +166,19 @@ class MovementMessageSpec extends AnyFreeSpec with Matchers with ScalaCheckPrope
 
       "must succeed when the json does not contain the `messageJson` node, setting that field to an empty Json object" in {
 
-        forAll(arbitrary[LocalDateTime], arbitrary[MessageType], arbitrary[Int]) {
-          case (dateTime, messageType, messageCorrelationId) =>
+        forAll(arbitrary[MessageId], arbitrary[LocalDateTime], arbitrary[MessageType], arbitrary[Int]) {
+          case (messageId, dateTime, messageType, messageCorrelationId) =>
             val xml = <xml><node1>foo</node1><node2>bar</node2></xml>
 
             val json = Json.obj(
+              "messageId"            -> Json.toJson(messageId),
               "dateTime"             -> Json.toJson(dateTime)(MongoDateTimeFormats.localDateTimeWrite),
               "messageType"          -> Json.toJson(messageType),
               "message"              -> xml.toString,
               "messageCorrelationId" -> messageCorrelationId
             )
 
-            val expectedMovementMessage = MovementMessageWithoutStatus(dateTime, messageType, xml, messageCorrelationId, Json.obj())
+            val expectedMovementMessage = MovementMessageWithoutStatus(messageId, dateTime, messageType, xml, messageCorrelationId, Json.obj())
 
             json.validate[MovementMessageWithoutStatus] mustEqual JsSuccess(expectedMovementMessage)
         }

--- a/test/models/response/ResponseArrivalSpec.scala
+++ b/test/models/response/ResponseArrivalSpec.scala
@@ -66,6 +66,7 @@ class ResponseArrivalSpec extends SpecBase with ScalaCheckPropertyChecks with Mo
     </CC007A>
 
   def movementMessage(messageCorrelationId: Int): MovementMessageWithStatus = MovementMessageWithStatus(
+    MessageId(1),
     localDateTime,
     MessageType.ArrivalNotification,
     savedXmlMessage(messageCorrelationId).map(trim),

--- a/test/models/response/ResponseArrivalWithMessagesSpec.scala
+++ b/test/models/response/ResponseArrivalWithMessagesSpec.scala
@@ -66,6 +66,7 @@ class ResponseArrivalWithMessagesSpec extends SpecBase with ScalaCheckPropertyCh
     </CC007A>
 
   def movementMessage(messageCorrelationId: Int): MovementMessageWithStatus = MovementMessageWithStatus(
+    MessageId(1),
     localDateTime,
     MessageType.ArrivalNotification,
     savedXmlMessage(messageCorrelationId).map(trim),

--- a/test/services/ArrivalMessageSummaryServiceSpec.scala
+++ b/test/services/ArrivalMessageSummaryServiceSpec.scala
@@ -23,7 +23,6 @@ import models.MessageStatus._
 import models.MessageType._
 import models.Arrival
 import models.ArrivalStatus
-import models.MessageId
 import models.MessageType
 import models.MessagesSummary
 import models.MovementMessage
@@ -72,7 +71,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
                 val (message, messageId) = service.arrivalNotificationR(arrival)
 
                 message mustEqual ie007
-                messageId mustEqual MessageId.fromMessageIdValue(1).value
+                messageId mustEqual ie007.messageId
 
             }
         }
@@ -90,7 +89,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
                 val (message, messageId) = service.arrivalNotificationR(arrival)
 
                 message mustEqual ie007
-                messageId mustEqual MessageId.fromMessageIdValue(1).value
+                messageId mustEqual ie007.messageId
             }
         }
 
@@ -108,7 +107,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
                 val (message, messageId) = service.arrivalNotificationR(arrival)
 
                 message mustEqual ie007
-                messageId mustEqual MessageId.fromMessageIdValue(3).value
+                messageId mustEqual ie007.messageId
             }
         }
 
@@ -126,7 +125,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
                 val (message, messageId) = service.arrivalNotificationR(arrival)
 
                 message mustEqual ie007
-                messageId mustEqual MessageId.fromMessageIdValue(3).value
+                messageId mustEqual ie007.messageId
             }
         }
 
@@ -145,7 +144,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
           ie007 =>
             forAll(arrivalMovement(NonEmptyList.one(ie007))) {
               arrival =>
-                service.arrivalRejectionR(arrival) must not be (defined)
+                service.arrivalRejectionR(arrival) must not be defined
 
             }
         }
@@ -163,7 +162,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
                 val (message, messageId) = service.arrivalRejectionR(arrival).value
 
                 message mustEqual ie008
-                messageId mustEqual MessageId.fromMessageIdValue(2).value
+                messageId mustEqual ie008.messageId
             }
         }
 
@@ -178,7 +177,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
 
             forAll(arrivalMovement(messages)) {
               arrival =>
-                service.arrivalRejectionR(arrival) must not be (defined)
+                service.arrivalRejectionR(arrival) must not be defined
             }
         }
 
@@ -196,7 +195,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
                 val (message, messageId) = service.arrivalRejectionR(arrival).value
 
                 message mustEqual ie008
-                messageId mustEqual MessageId.fromMessageIdValue(4).value
+                messageId mustEqual ie008.messageId
             }
         }
 
@@ -215,7 +214,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
           ie007 =>
             forAll(arrivalMovement(NonEmptyList.one(ie007))) {
               arrival =>
-                service.xmlSubmissionNegativeAcknowledgementR(arrival) must not be (defined)
+                service.xmlSubmissionNegativeAcknowledgementR(arrival) must not be defined
 
             }
         }
@@ -233,7 +232,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
                 val (message, messageId) = service.xmlSubmissionNegativeAcknowledgementR(arrival).value
 
                 message mustEqual ie917
-                messageId mustEqual MessageId.fromMessageIdValue(2).value
+                messageId mustEqual ie917.messageId
             }
         }
 
@@ -251,7 +250,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
                 val (message, messageId) = service.xmlSubmissionNegativeAcknowledgementR(arrival).value
 
                 message mustEqual ie917
-                messageId mustEqual MessageId.fromMessageIdValue(3).value
+                messageId mustEqual ie917.messageId
             }
         }
 
@@ -269,7 +268,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
                 val (message, messageId) = service.xmlSubmissionNegativeAcknowledgementR(arrival).value
 
                 message mustEqual ie917
-                messageId mustEqual MessageId.fromMessageIdValue(4).value
+                messageId mustEqual ie917.messageId
             }
         }
 
@@ -289,7 +288,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
           ie007 =>
             forAll(arrivalMovement(NonEmptyList.one(ie007))) {
               arrival =>
-                service.unloadingPermissionR(arrival) must not be (defined)
+                service.unloadingPermissionR(arrival) must not be defined
 
             }
         }
@@ -302,7 +301,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
           ie043 =>
             forAll(arrivalMovement(NonEmptyList.one(ie043))) {
               arrival =>
-                service.unloadingPermissionR(arrival) must not be (defined)
+                service.unloadingPermissionR(arrival) must not be defined
 
             }
         }
@@ -320,7 +319,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
                 val (message, messageId) = service.unloadingPermissionR(arrival).value
 
                 message mustEqual ie043
-                messageId mustEqual MessageId.fromMessageIdValue(2).value
+                messageId mustEqual ie043.messageId
             }
         }
 
@@ -338,7 +337,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
                 val (message, messageId) = service.unloadingPermissionR(arrival).value
 
                 message mustEqual ie043a
-                messageId mustEqual MessageId.fromMessageIdValue(2).value
+                messageId mustEqual ie043a.messageId
             }
         }
 
@@ -356,7 +355,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
                 val (message, messageId) = service.unloadingPermissionR(arrival).value
 
                 message mustEqual ie043
-                messageId mustEqual MessageId.fromMessageIdValue(2).value
+                messageId mustEqual ie043.messageId
             }
         }
 
@@ -374,7 +373,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
                 val (message, messageId) = service.unloadingPermissionR(arrival).value
 
                 message mustEqual ie043
-                messageId mustEqual MessageId.fromMessageIdValue(2).value
+                messageId mustEqual ie043.messageId
             }
         }
 
@@ -395,7 +394,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
           ie007 =>
             forAll(arrivalMovement(NonEmptyList.one(ie007))) {
               arrival =>
-                service.unloadingRemarksR(arrival) must not be (defined)
+                service.unloadingRemarksR(arrival) must not be defined
 
             }
         }
@@ -413,6 +412,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
                 val (message, messageId) = service.unloadingRemarksR(arrival).value
 
                 message mustEqual ie044
+                messageId mustEqual ie044.messageId
             }
         }
 
@@ -430,7 +430,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
                 val (message, messageId) = service.unloadingRemarksR(arrival).value
 
                 message mustEqual ie044
-                messageId mustEqual MessageId.fromMessageIdValue(5).value
+                messageId mustEqual ie044.messageId
             }
         }
 
@@ -448,7 +448,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
                 val (message, messageId) = service.unloadingRemarksR(arrival).value
 
                 message mustEqual ie044
-                messageId mustEqual MessageId.fromMessageIdValue(3).value
+                messageId mustEqual ie044.messageId
             }
         }
 
@@ -457,12 +457,14 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
       "latest IE044 when multiple IE058 messages exist" in {
         val service = new ArrivalMessageSummaryService
 
-        forAll(ie007Gen.submitted.msgCorrId(1),
-               ie043Gen.msgCorrId(2),
-               ie044Gen.msgCorrId(3),
-               ie058Gen.msgCorrId(4),
-               ie044Gen.msgCorrId(5),
-               ie058Gen.msgCorrId(6)) {
+        forAll(
+          ie007Gen.submitted.msgCorrId(1),
+          ie043Gen.msgCorrId(2),
+          ie044Gen.msgCorrId(3),
+          ie058Gen.msgCorrId(4),
+          ie044Gen.msgCorrId(5),
+          ie058Gen.msgCorrId(6)
+        ) {
           case (ie007, ie043, ie044Old, ie058Old, ie044, ie058) =>
             val messages = NonEmptyList.of(ie007, ie043, ie044Old, ie058Old, ie044, ie058)
 
@@ -471,7 +473,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
                 val (message, messageId) = service.unloadingRemarksR(arrival).value
 
                 message mustEqual ie044
-                messageId mustEqual MessageId.fromMessageIdValue(5).value
+                messageId mustEqual ie044.messageId
             }
         }
 
@@ -492,7 +494,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
           ie007 =>
             forAll(arrivalMovement(NonEmptyList.one(ie007))) {
               arrival =>
-                service.unloadingRemarksRejectionsR(arrival) must not be (defined)
+                service.unloadingRemarksRejectionsR(arrival) must not be defined
 
             }
         }
@@ -511,7 +513,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
                 val (message, messageId) = service.unloadingRemarksRejectionsR(arrival).value
 
                 message mustEqual ie058
-                messageId mustEqual MessageId.fromMessageIdValue(4).value
+                messageId mustEqual ie058.messageId
             }
         }
 
@@ -520,12 +522,14 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
       "latest IE058 when multiple IE058 messages exist" in {
         val service = new ArrivalMessageSummaryService
 
-        forAll(ie007Gen.submitted.msgCorrId(1),
-               ie043Gen.msgCorrId(2),
-               ie044Gen.msgCorrId(3),
-               ie058Gen.msgCorrId(4),
-               ie044Gen.msgCorrId(5),
-               ie058Gen.msgCorrId(6)) {
+        forAll(
+          ie007Gen.submitted.msgCorrId(1),
+          ie043Gen.msgCorrId(2),
+          ie044Gen.msgCorrId(3),
+          ie058Gen.msgCorrId(4),
+          ie044Gen.msgCorrId(5),
+          ie058Gen.msgCorrId(6)
+        ) {
           case (ie007, ie043, ie044Old, ie058Old, ie044, ie058) =>
             val messages = NonEmptyList.of(ie007, ie043, ie044Old, ie058Old, ie044, ie058)
 
@@ -535,7 +539,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
                 val (message, messageId) = service.unloadingRemarksRejectionsR(arrival).value
 
                 message mustEqual ie058
-                messageId mustEqual MessageId.fromMessageIdValue(6).value
+                messageId mustEqual ie058.messageId
             }
         }
 
@@ -555,7 +559,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
           ie007 =>
             forAll(arrivalMovement(NonEmptyList.one(ie007))) {
               arrival =>
-                service.arrivalMessagesSummary(arrival) mustEqual MessagesSummary(arrival, MessageId.fromMessageIdValue(1).value, None)
+                service.arrivalMessagesSummary(arrival) mustEqual MessagesSummary(arrival, ie007.messageId, None)
 
             }
         }
@@ -570,7 +574,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
 
             forAll(arrivalMovement(messages)) {
               arrival =>
-                val expectedMessageSummary = MessagesSummary(arrival, MessageId.fromMessageIdValue(1).value, MessageId.fromMessageIdValue(2))
+                val expectedMessageSummary = MessagesSummary(arrival, ie007.messageId, Some(ie008.messageId))
 
                 service.arrivalMessagesSummary(arrival) mustEqual expectedMessageSummary
             }
@@ -587,7 +591,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
 
             forAll(arrivalMovement(messages)) {
               arrival =>
-                val expectedMessageSummary = MessagesSummary(arrival, MessageId.fromMessageIdValue(3).value, None)
+                val expectedMessageSummary = MessagesSummary(arrival, ie007.messageId, None)
 
                 service.arrivalMessagesSummary(arrival) mustEqual expectedMessageSummary
             }
@@ -604,7 +608,7 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
 
             forAll(arrivalMovement(messages)) {
               arrival =>
-                val expectedMessageSummary = MessagesSummary(arrival, MessageId.fromMessageIdValue(3).value, MessageId.fromMessageIdValue(4))
+                val expectedMessageSummary = MessagesSummary(arrival, ie007.messageId, Some(ie008.messageId))
 
                 service.arrivalMessagesSummary(arrival) mustEqual expectedMessageSummary
             }
@@ -616,13 +620,13 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
         val service = new ArrivalMessageSummaryService
 
         forAll(ie007Gen.submitted.msgCorrId(1), ie043Gen.msgCorrId(2)) {
-          case (ie007, ie0043) =>
-            val messages = NonEmptyList.of(ie007, ie0043)
+          case (ie007, ie043) =>
+            val messages = NonEmptyList.of(ie007, ie043)
 
             forAll(arrivalMovement(messages)) {
               arrival =>
                 val expectedMessageSummary =
-                  MessagesSummary(arrival, MessageId.fromMessageIdValue(1).value, None, MessageId.fromMessageIdValue(2), None, None)
+                  MessagesSummary(arrival, ie007.messageId, None, Some(ie043.messageId), None, None)
 
                 service.arrivalMessagesSummary(arrival) mustEqual expectedMessageSummary
             }
@@ -634,13 +638,13 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
         val service = new ArrivalMessageSummaryService
 
         forAll(ie007Gen.submitted.msgCorrId(1), ie043Gen.msgCorrId(2), ie044Gen.msgCorrId(3)) {
-          case (ie007, ie0043, ie044) =>
-            val messages = NonEmptyList.of(ie007, ie0043, ie044)
+          case (ie007, ie043, ie044) =>
+            val messages = NonEmptyList.of(ie007, ie043, ie044)
 
             forAll(arrivalMovement(messages)) {
               arrival =>
                 val expectedMessageSummary =
-                  MessagesSummary(arrival, MessageId.fromMessageIdValue(1).value, None, MessageId.fromMessageIdValue(2), MessageId.fromMessageIdValue(3), None)
+                  MessagesSummary(arrival, ie007.messageId, None, Some(ie043.messageId), Some(ie044.messageId), None)
 
                 service.arrivalMessagesSummary(arrival) mustEqual expectedMessageSummary
             }
@@ -652,14 +656,14 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
         val service = new ArrivalMessageSummaryService
 
         forAll(ie007Gen.submitted.msgCorrId(1), ie043Gen.msgCorrId(2), ie044Gen.msgCorrId(3), ie058Gen.msgCorrId(4), ie044Gen.msgCorrId(5)) {
-          case (ie007, ie0043, ie044Old, ie058, ie044) =>
-            val messages = NonEmptyList.of(ie007, ie0043, ie044Old, ie058, ie044)
+          case (ie007, ie043, ie044Old, ie058, ie044) =>
+            val messages = NonEmptyList.of(ie007, ie043, ie044Old, ie058, ie044)
 
             forAll(arrivalMovement(messages)) {
               arr =>
                 val arrival = arr.copy(status = ArrivalStatus.UnloadingRemarksSubmitted)
                 val expectedMessageSummary =
-                  MessagesSummary(arrival, MessageId.fromMessageIdValue(1).value, None, MessageId.fromMessageIdValue(2), MessageId.fromMessageIdValue(5), None)
+                  MessagesSummary(arrival, ie007.messageId, None, Some(ie043.messageId), Some(ie044.messageId), None)
 
                 service.arrivalMessagesSummary(arrival) mustEqual expectedMessageSummary
             }
@@ -670,26 +674,23 @@ class ArrivalMessageSummaryServiceSpec extends SpecBase with ModelGenerators wit
       "latest IE044 and IE058 when there has been multiple corrections without a successful IE044 correction and state is UnloadingRemarksRejected" in {
         val service = new ArrivalMessageSummaryService
 
-        forAll(ie007Gen.submitted.msgCorrId(1),
-               ie043Gen.msgCorrId(2),
-               ie044Gen.msgCorrId(3),
-               ie058Gen.msgCorrId(4),
-               ie044Gen.msgCorrId(5),
-               ie058Gen.msgCorrId(6)) {
-          case (ie007, ie0043, ie044Old, ie058Old, ie044, ie058) =>
-            val messages = NonEmptyList.of(ie007, ie0043, ie044Old, ie058Old, ie044, ie058)
+        forAll(
+          ie007Gen.submitted.msgCorrId(1),
+          ie043Gen.msgCorrId(2),
+          ie044Gen.msgCorrId(3),
+          ie058Gen.msgCorrId(4),
+          ie044Gen.msgCorrId(5),
+          ie058Gen.msgCorrId(6)
+        ) {
+          case (ie007, ie043, ie044Old, ie058Old, ie044, ie058) =>
+            val messages = NonEmptyList.of(ie007, ie043, ie044Old, ie058Old, ie044, ie058)
 
             forAll(arrivalMovement(messages)) {
               arr =>
                 val arrival = arr.copy(status = ArrivalStatus.UnloadingRemarksRejected)
 
                 val expectedMessageSummary =
-                  MessagesSummary(arrival,
-                                  MessageId.fromMessageIdValue(1).value,
-                                  None,
-                                  MessageId.fromMessageIdValue(2),
-                                  MessageId.fromMessageIdValue(5),
-                                  MessageId.fromMessageIdValue(6))
+                  MessagesSummary(arrival, ie007.messageId, None, Some(ie043.messageId), Some(ie044.messageId), Some(ie058.messageId))
 
                 service.arrivalMessagesSummary(arrival) mustEqual expectedMessageSummary
             }

--- a/test/services/MessageRetrievalServiceSpec.scala
+++ b/test/services/MessageRetrievalServiceSpec.scala
@@ -44,9 +44,8 @@ class MessageRetrievalServiceSpec extends SpecBase with ModelGenerators with Sca
             val unloadingPermissionMessage     = movementMessageWithStatus.copy(messageType = UnloadingPermission)
             val arrivalWithUnloadingPermission = arrival.copy(messages = NonEmptyList(movementMessageWithStatus, List(unloadingPermissionMessage)))
 
-            val arrivalSummary = MessagesSummary(arrivalNotification = MessageId.fromIndex(0),
-                                                 unloadingPermission = Some(MessageId.fromIndex(1)),
-                                                 arrival = arrivalWithUnloadingPermission)
+            val arrivalSummary =
+              MessagesSummary(arrivalNotification = MessageId(1), unloadingPermission = Some(MessageId(2)), arrival = arrivalWithUnloadingPermission)
 
             when(mockArrivalMessageSummaryService.arrivalMessagesSummary(any())).thenReturn(arrivalSummary)
 
@@ -55,7 +54,7 @@ class MessageRetrievalServiceSpec extends SpecBase with ModelGenerators with Sca
             running(application) {
               val service = application.injector.instanceOf[MessageRetrievalService]
 
-              val expectedResult = ResponseMovementMessage.build(arrivalWithUnloadingPermission.arrivalId, MessageId.fromIndex(1), unloadingPermissionMessage)
+              val expectedResult = ResponseMovementMessage.build(arrivalWithUnloadingPermission.arrivalId, MessageId(2), unloadingPermissionMessage)
 
               service.getUnloadingPermission(arrivalWithUnloadingPermission).value mustBe expectedResult
             }
@@ -65,7 +64,7 @@ class MessageRetrievalServiceSpec extends SpecBase with ModelGenerators with Sca
       "must return None when UnloadingPermission MessageId cannot be found" in {
         forAll(arbitrary[Arrival]) {
           arrival =>
-            val arrivalSummary = MessagesSummary(arrivalNotification = MessageId.fromIndex(0), unloadingPermission = None, arrival = arrival)
+            val arrivalSummary = MessagesSummary(arrivalNotification = MessageId(1), unloadingPermission = None, arrival = arrival)
 
             when(mockArrivalMessageSummaryService.arrivalMessagesSummary(any())).thenReturn(arrivalSummary)
 
@@ -84,9 +83,8 @@ class MessageRetrievalServiceSpec extends SpecBase with ModelGenerators with Sca
           (arrival, movementMessageWithStatus) =>
             val arrivalWithoutUnloadingPermission = arrival.copy(messages = NonEmptyList(movementMessageWithStatus, List.empty))
 
-            val arrivalSummary = MessagesSummary(arrivalNotification = MessageId.fromIndex(0),
-                                                 unloadingPermission = Some(MessageId.fromIndex(1)),
-                                                 arrival = arrivalWithoutUnloadingPermission)
+            val arrivalSummary =
+              MessagesSummary(arrivalNotification = MessageId(1), unloadingPermission = Some(MessageId(2)), arrival = arrivalWithoutUnloadingPermission)
 
             when(mockArrivalMessageSummaryService.arrivalMessagesSummary(any())).thenReturn(arrivalSummary)
 

--- a/test/services/PushPullNotificationServiceSpec.scala
+++ b/test/services/PushPullNotificationServiceSpec.scala
@@ -100,12 +100,8 @@ class PushPullNotificationServiceSpec extends SpecBase with BeforeAndAfterEach w
       "should return a unit value when connector call succeeds" in {
         val testArrivalId  = ArrivalId(1)
         val testMessageUri = requestId(testArrivalId) + "/messages" + ""
-        val testNotification = ArrivalMessageNotification(testMessageUri,
-                                                          requestId(testArrivalId),
-                                                          testArrivalId,
-                                                          MessageId.fromIndex(1),
-                                                          LocalDateTime.now,
-                                                          MessageType.UnloadingPermission)
+        val testNotification =
+          ArrivalMessageNotification(testMessageUri, requestId(testArrivalId), testArrivalId, MessageId(2), LocalDateTime.now, MessageType.UnloadingPermission)
 
         val boxIdMatcher = refEq(testBoxId).asInstanceOf[BoxId]
 
@@ -120,12 +116,8 @@ class PushPullNotificationServiceSpec extends SpecBase with BeforeAndAfterEach w
       "should not return anything when call fails" in {
         val testArrivalId  = ArrivalId(1)
         val testMessageUri = requestId(testArrivalId) + "/messages" + ""
-        val testNotification = ArrivalMessageNotification(testMessageUri,
-                                                          requestId(testArrivalId),
-                                                          testArrivalId,
-                                                          MessageId.fromIndex(1),
-                                                          LocalDateTime.now,
-                                                          MessageType.UnloadingPermission)
+        val testNotification =
+          ArrivalMessageNotification(testMessageUri, requestId(testArrivalId), testArrivalId, MessageId(2), LocalDateTime.now, MessageType.UnloadingPermission)
 
         val boxIdMatcher = refEq(testBoxId).asInstanceOf[BoxId]
 

--- a/test/services/SaveMessageServiceSpec.scala
+++ b/test/services/SaveMessageServiceSpec.scala
@@ -16,15 +16,13 @@
 
 package services
 
-import java.time.LocalDate
-import java.time.LocalTime
-
 import audit.AuditService
 import base.SpecBase
-import models.ArrivalStatus._
 import models.ArrivalId
+import models.ArrivalStatus._
 import models.ChannelType
 import models.GoodsReleasedResponse
+import models.MessageId
 import models.MessageSender
 import models.SubmissionProcessingResult
 import org.mockito.ArgumentMatchers.{eq => eqTo, _}
@@ -35,6 +33,8 @@ import play.api.test.Helpers.running
 import repositories.ArrivalMovementRepository
 import utils.Format
 
+import java.time.LocalDate
+import java.time.LocalTime
 import scala.concurrent.Future
 import scala.util.Failure
 import scala.util.Success
@@ -84,7 +84,9 @@ class SaveMessageServiceSpec extends SpecBase with BeforeAndAfterEach {
           </CC025A>
 
         val result =
-          saveMessageService.validateXmlAndSaveMessage(requestGoodsReleasedXmlBody, messageSender, GoodsReleasedResponse, GoodsReleased, channel).futureValue
+          saveMessageService
+            .validateXmlAndSaveMessage(MessageId(2), requestGoodsReleasedXmlBody, messageSender, GoodsReleasedResponse, GoodsReleased, channel)
+            .futureValue
 
         result mustBe SubmissionProcessingResult.SubmissionSuccess
         verify(mockArrivalMovementRepository, times(1)).addResponseMessage(eqTo(arrivalId), any(), eqTo(GoodsReleased))
@@ -122,7 +124,9 @@ class SaveMessageServiceSpec extends SpecBase with BeforeAndAfterEach {
           </CC025A>
 
         val result =
-          saveMessageService.validateXmlAndSaveMessage(requestGoodsReleasedXmlBody, messageSender, GoodsReleasedResponse, GoodsReleased, channel).futureValue
+          saveMessageService
+            .validateXmlAndSaveMessage(MessageId(2), requestGoodsReleasedXmlBody, messageSender, GoodsReleasedResponse, GoodsReleased, channel)
+            .futureValue
 
         result mustBe SubmissionProcessingResult.SubmissionFailureInternal
         verify(mockArrivalMovementRepository, times(1)).addResponseMessage(any(), any(), any())
@@ -151,7 +155,9 @@ class SaveMessageServiceSpec extends SpecBase with BeforeAndAfterEach {
         val requestInvalidXmlBody = <Invalid>invalid</Invalid>
 
         val result =
-          saveMessageService.validateXmlAndSaveMessage(requestInvalidXmlBody, messageSender, GoodsReleasedResponse, GoodsReleased, channel).futureValue
+          saveMessageService
+            .validateXmlAndSaveMessage(MessageId(2), requestInvalidXmlBody, messageSender, GoodsReleasedResponse, GoodsReleased, channel)
+            .futureValue
 
         result mustBe SubmissionProcessingResult.SubmissionFailureExternal
         verify(mockArrivalMovementRepository, never()).addResponseMessage(any(), any(), any())
@@ -186,7 +192,9 @@ class SaveMessageServiceSpec extends SpecBase with BeforeAndAfterEach {
           </CC025A>
 
         val result =
-          saveMessageService.validateXmlAndSaveMessage(requestInvalidXmlBody, messageSender, GoodsReleasedResponse, GoodsReleased, channel).futureValue
+          saveMessageService
+            .validateXmlAndSaveMessage(MessageId(2), requestInvalidXmlBody, messageSender, GoodsReleasedResponse, GoodsReleased, channel)
+            .futureValue
 
         result mustBe SubmissionProcessingResult.SubmissionFailureExternal
         verify(mockArrivalMovementRepository, never()).addResponseMessage(any(), any(), any())

--- a/test/services/SubmitMessageServiceSpec.scala
+++ b/test/services/SubmitMessageServiceSpec.scala
@@ -81,9 +81,10 @@ class SubmitMessageServiceSpec extends SpecBase with ScalaCheckDrivenPropertyChe
       </HEAHEA>
     </CC007A>
 
-  val messageId = MessageId.fromIndex(0)
+  val messageId = MessageId(1)
 
   val movementMessage = MovementMessageWithStatus(
+    messageId,
     localDateTime,
     MessageType.ArrivalNotification,
     requestXmlBody,
@@ -93,14 +94,13 @@ class SubmitMessageServiceSpec extends SpecBase with ScalaCheckDrivenPropertyChe
 
   val arrivalWithOneMessage: Gen[Arrival] = for {
     arrival <- arbitrary[Arrival]
-  } yield {
+  } yield
     arrival.copy(
       eoriNumber = "eori",
       status = ArrivalStatus.ArrivalSubmitted,
       messages = NonEmptyList.one(movementMessage),
       nextMessageCorrelationId = movementMessage.messageCorrelationId
     )
-  }
 
   "submit a new message" - {
     "return SubmissionSuccess and set the message status to submitted when the message is successfully saved, submitted" in {
@@ -133,10 +133,12 @@ class SubmitMessageServiceSpec extends SpecBase with ScalaCheckDrivenPropertyChe
 
         verify(mockArrivalMovementRepository, times(1)).addNewMessage(eqTo(arrivalId), eqTo(movementMessage))
         verify(mockMessageConnector, times(1)).post(eqTo(arrivalId), eqTo(movementMessage), any(), any())(any())
-        verify(mockArrivalMovementRepository, times(1)).setArrivalStateAndMessageState(eqTo(arrivalId),
-                                                                                       eqTo(messageId),
-                                                                                       eqTo(ArrivalStatus.ArrivalSubmitted),
-                                                                                       eqTo(MessageStatus.SubmissionSucceeded))
+        verify(mockArrivalMovementRepository, times(1)).setArrivalStateAndMessageState(
+          eqTo(arrivalId),
+          eqTo(messageId),
+          eqTo(ArrivalStatus.ArrivalSubmitted),
+          eqTo(MessageStatus.SubmissionSucceeded)
+        )
 
       }
     }
@@ -170,10 +172,12 @@ class SubmitMessageServiceSpec extends SpecBase with ScalaCheckDrivenPropertyChe
         result.futureValue mustEqual SubmissionProcessingResult.SubmissionSuccess
         verify(mockArrivalMovementRepository, times(1)).addNewMessage(eqTo(arrivalId), eqTo(movementMessage))
         verify(mockMessageConnector, times(1)).post(eqTo(arrivalId), eqTo(movementMessage), any(), any())(any())
-        verify(mockArrivalMovementRepository, times(1)).setArrivalStateAndMessageState(eqTo(arrivalId),
-                                                                                       eqTo(messageId),
-                                                                                       eqTo(ArrivalStatus.ArrivalSubmitted),
-                                                                                       eqTo(MessageStatus.SubmissionSucceeded))
+        verify(mockArrivalMovementRepository, times(1)).setArrivalStateAndMessageState(
+          eqTo(arrivalId),
+          eqTo(messageId),
+          eqTo(ArrivalStatus.ArrivalSubmitted),
+          eqTo(MessageStatus.SubmissionSucceeded)
+        )
       }
 
     }
@@ -221,11 +225,13 @@ class SubmitMessageServiceSpec extends SpecBase with ScalaCheckDrivenPropertyChe
       running(application) {
         val service = application.injector.instanceOf[SubmitMessageService]
 
-        forAll(arbitrary[ArrivalId],
-               arbitrary[MessageId],
-               arbitrary[MovementMessageWithStatus],
-               arbitrary[ArrivalStatus],
-               arbitrary[EisSubmissionFailureDownstream]) {
+        forAll(
+          arbitrary[ArrivalId],
+          arbitrary[MessageId],
+          arbitrary[MovementMessageWithStatus],
+          arbitrary[ArrivalStatus],
+          arbitrary[EisSubmissionFailureDownstream]
+        ) {
           (arrivalId, messageId, movementMessage, arrivalStatus, submissionFailure) =>
             when(mockArrivalMovementRepository.addNewMessage(any(), any())).thenReturn(Future.successful(Success(())))
             when(mockMessageConnector.post(any(), any(), any(), any())(any())).thenReturn(Future.successful(submissionFailure))
@@ -650,10 +656,12 @@ class SubmitMessageServiceSpec extends SpecBase with ScalaCheckDrivenPropertyChe
         result.futureValue mustEqual SubmissionProcessingResult.SubmissionSuccess
         verify(mockArrivalMovementRepository, times(1)).insert(eqTo(arrival))
         verify(mockMessageConnector, times(1)).post(eqTo(arrival.arrivalId), eqTo(movementMessage), any(), any())(any())
-        verify(mockArrivalMovementRepository, times(1)).setArrivalStateAndMessageState(eqTo(arrival.arrivalId),
-                                                                                       eqTo(messageId),
-                                                                                       eqTo(ArrivalStatus.ArrivalSubmitted),
-                                                                                       eqTo(MessageStatus.SubmissionSucceeded))
+        verify(mockArrivalMovementRepository, times(1)).setArrivalStateAndMessageState(
+          eqTo(arrival.arrivalId),
+          eqTo(messageId),
+          eqTo(ArrivalStatus.ArrivalSubmitted),
+          eqTo(MessageStatus.SubmissionSucceeded)
+        )
       }
 
     }


### PR DESCRIPTION
Companion PR for hmrc/transits-movements-trader-at-departure#120.

This adds the message ID as a property of the message that is saved in Mongo.

I have made the message ID an incrementing number starting from 1 but I have not added a repository to track this since we lock the arrival when saving messages. 

This preserves compatibility with any current message URLs that users have saved as the existing code used to increment the positional array index before rendering to a path.

I have also added a [Mongock](https://www.mongock.io/) migration runner and added a changelog to migrate the existing messages.

I think this is a prerequisite for doing any filtering of the messages in Mongo rather than in memory as it ensures that we can provide accurate message resource paths in the various API responses.