### PR TITLE
CTDA-1528 Include message body in push notifications when it is <= 100kB

### DIFF
--- a/app/models/ArrivalMessageNotification.scala
+++ b/app/models/ArrivalMessageNotification.scala
@@ -71,7 +71,7 @@ object ArrivalMessageNotification {
       messageId,
       timestamp,
       request.message.messageType.messageType,
-      if (bodySize.exists(_ <= oneHundredKilobytes)) Some(request.body) else None
+      if (bodySize.exists(_ < oneHundredKilobytes)) Some(request.body) else None
     )
   }
 }

--- a/test/connectors/PushPullNotificationConnectorSpec.scala
+++ b/test/connectors/PushPullNotificationConnectorSpec.scala
@@ -32,8 +32,8 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks._
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HeaderCarrier
-import java.time.LocalDateTime
 
+import java.time.LocalDateTime
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class PushPullNotificationConnectorSpec extends AnyFreeSpec with WiremockSuite with ScalaFutures with Matchers with IntegrationPatience {
@@ -128,14 +128,18 @@ class PushPullNotificationConnectorSpec extends AnyFreeSpec with WiremockSuite w
     "postNotification" - {
 
       val testBoxId      = "1c5b9365-18a6-55a5-99c9-83a091ac7f26"
+      val testBody       = <test>some text</test>
       val testArrivalId  = ArrivalId(1)
       val testMessageUri = requestId(testArrivalId) + "/messages" + ""
-      val testNotification = ArrivalMessageNotification(testMessageUri,
-                                                        requestId(testArrivalId),
-                                                        testArrivalId,
-                                                        MessageId.fromIndex(1),
-                                                        LocalDateTime.now,
-                                                        MessageType.UnloadingPermission)
+      val testNotification = ArrivalMessageNotification(
+        testMessageUri,
+        requestId(testArrivalId),
+        testArrivalId,
+        MessageId.fromIndex(1),
+        LocalDateTime.now,
+        MessageType.UnloadingPermission,
+        Some(testBody)
+      )
 
       val testUrlPath = s"/box/$testBoxId/notifications"
 

--- a/test/models/ArrivalMessageNotificationSpec.scala
+++ b/test/models/ArrivalMessageNotificationSpec.scala
@@ -60,7 +60,7 @@ class ArrivalMessageNotificationSpec extends SpecBase with ScalaCheckDrivenPrope
           s"/customs/transits/movements/arrivals/${arrival.arrivalId.index}",
           arrival.eoriNumber,
           arrival.arrivalId,
-          MessageId.fromIndex(arrival.messages.length),
+          MessageId(arrival.messages.length + 1),
           now,
           response.messageType,
           Some(<text></text>)

--- a/test/models/ArrivalMessageNotificationSpec.scala
+++ b/test/models/ArrivalMessageNotificationSpec.scala
@@ -58,6 +58,7 @@ class ArrivalMessageNotificationSpec extends SpecBase with ScalaCheckDrivenPrope
         ArrivalMessageNotification(
           s"/customs/transits/movements/arrivals/${arrival.arrivalId.index}/messages/${arrival.messages.length + 1}",
           s"/customs/transits/movements/arrivals/${arrival.arrivalId.index}",
+          arrival.eoriNumber,
           arrival.arrivalId,
           MessageId.fromIndex(arrival.messages.length),
           now,

--- a/test/services/PushPullNotificationServiceSpec.scala
+++ b/test/services/PushPullNotificationServiceSpec.scala
@@ -34,14 +34,13 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.UpstreamErrorResponse
-import java.time.LocalDateTime
 
+import java.time.LocalDateTime
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.xml.NodeSeq
 
 class PushPullNotificationServiceSpec extends SpecBase with BeforeAndAfterEach with ScalaCheckPropertyChecks {
   val mockConnector = mock[PushPullNotificationConnector]
@@ -100,12 +99,16 @@ class PushPullNotificationServiceSpec extends SpecBase with BeforeAndAfterEach w
       "should return a unit value when connector call succeeds" in {
         val testArrivalId  = ArrivalId(1)
         val testMessageUri = requestId(testArrivalId) + "/messages" + ""
-        val testNotification = ArrivalMessageNotification(testMessageUri,
-                                                          requestId(testArrivalId),
-                                                          testArrivalId,
-                                                          MessageId.fromIndex(1),
-                                                          LocalDateTime.now,
-                                                          MessageType.UnloadingPermission)
+        val testBody       = <test>test content</test>
+        val testNotification = ArrivalMessageNotification(
+          testMessageUri,
+          requestId(testArrivalId),
+          testArrivalId,
+          MessageId.fromIndex(1),
+          LocalDateTime.now,
+          MessageType.UnloadingPermission,
+          Some(testBody)
+        )
 
         val boxIdMatcher = refEq(testBoxId).asInstanceOf[BoxId]
 
@@ -120,12 +123,16 @@ class PushPullNotificationServiceSpec extends SpecBase with BeforeAndAfterEach w
       "should not return anything when call fails" in {
         val testArrivalId  = ArrivalId(1)
         val testMessageUri = requestId(testArrivalId) + "/messages" + ""
-        val testNotification = ArrivalMessageNotification(testMessageUri,
-                                                          requestId(testArrivalId),
-                                                          testArrivalId,
-                                                          MessageId.fromIndex(1),
-                                                          LocalDateTime.now,
-                                                          MessageType.UnloadingPermission)
+        val testBody       = <test>test content</test>
+        val testNotification = ArrivalMessageNotification(
+          testMessageUri,
+          requestId(testArrivalId),
+          testArrivalId,
+          MessageId.fromIndex(1),
+          LocalDateTime.now,
+          MessageType.UnloadingPermission,
+          Some(testBody)
+        )
 
         val boxIdMatcher = refEq(testBoxId).asInstanceOf[BoxId]
 


### PR DESCRIPTION
Uses the `Content-Length` header in order to avoid repeatedly rendering the message in memory.