### PR TITLE
CTDA-1535 Tell Mongock not to fail if it can't acquire a lock on the current instance

### DIFF
--- a/app/migrations/MigrationRunner.scala
+++ b/app/migrations/MigrationRunner.scala
@@ -53,6 +53,7 @@ class MigrationRunner @Inject()(config: Configuration)(implicit ec: ExecutionCon
       .builder()
       .setDriver(mongoDriver)
       .addChangeLogsScanPackage("migrations.changelogs")
+      .dontFailIfCannotAcquireLock()
       .setMigrationStartedListener(
         () => logger.info("Started Mongock migrations")
       )


### PR DESCRIPTION
The default behaviour is to throw an exception instead of just not running migrations