### PR TITLE
Ensure message ID migration always runs

### DIFF
--- a/app/migrations/changelogs/MovementsChangeLog.scala
+++ b/app/migrations/changelogs/MovementsChangeLog.scala
@@ -29,7 +29,7 @@ import scala.collection.JavaConverters._
 @ChangeLog(order = "001")
 class MovementsChangeLog {
 
-  @ChangeSet(order = "001", id = "addMessageIdToMessages", author = "transit-movements-trader-at-destination")
+  @ChangeSet(order = "001", id = "addMessageIdToMessages", author = "transit-movements-trader-at-destination", runAlways = true)
   def addMessageIdToMessages(mongo: MongoDatabase): Unit = {
     val collection = mongo.getCollection(ArrivalMovementRepository.collectionName)
 


### PR DESCRIPTION
This enables the message ID migration on every startup for now.

Due to the fact that we had to back this out the first time, there is now a lot of data written in the old format into Mongo so the migration needs to run again.