### PR TITLE
CTCTRADERS-2761 Change PDF download code to stream data

### DIFF
--- a/app/models/PdfDocument.scala
+++ b/app/models/PdfDocument.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+
+case class PdfDocument(
+  dataSource: Source[ByteString, _],
+  contentLength: Option[Long],
+  contentType: Option[String],
+  contentDisposition: Option[String]
+)


### PR DESCRIPTION
I think this is only the first part of the memory usage issues that we have with this endpoint - the other half is in the code which fetches all of the movement messages in order to get the release for transit message XML.