### PR TITLE
CTDA-1585: Pull only required messages for PDFGenerationController

### DIFF
--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -23,6 +23,8 @@ import controllers.actions.AuthenticatedGetArrivalForReadActionProvider
 import controllers.actions.AuthenticatedGetArrivalForReadActionProviderImpl
 import controllers.actions.AuthenticatedGetArrivalWithoutMessagesForReadActionProvider
 import controllers.actions.AuthenticatedGetArrivalWithoutMessagesForReadActionProviderImpl
+import controllers.actions.AuthenticatedGetMessagesForReadActionProvider
+import controllers.actions.AuthenticatedGetMessagesForReadActionProviderImpl
 import repositories.ArrivalMovementRepository
 import utils.MessageTranslation
 import java.time.Clock
@@ -38,6 +40,7 @@ class Module extends AbstractModule {
     bind(classOf[AuthenticateActionProvider]).to(classOf[AuthenticateActionProviderImpl]).asEagerSingleton()
     bind(classOf[AuthenticatedGetArrivalForReadActionProvider]).to(classOf[AuthenticatedGetArrivalForReadActionProviderImpl])
     bind(classOf[AuthenticatedGetArrivalWithoutMessagesForReadActionProvider]).to(classOf[AuthenticatedGetArrivalWithoutMessagesForReadActionProviderImpl])
+    bind(classOf[AuthenticatedGetMessagesForReadActionProvider]).to(classOf[AuthenticatedGetMessagesForReadActionProviderImpl]).asEagerSingleton()
     bind(classOf[MessageTranslation]).asEagerSingleton()
     bind(classOf[StreamLoggingConfig]).to(classOf[StreamLoggingConfigImpl]).asEagerSingleton()
     bind(classOf[Clock]).toInstance(Clock.systemUTC)

--- a/app/connectors/ManageDocumentsConnector.scala
+++ b/app/connectors/ManageDocumentsConnector.scala
@@ -30,10 +30,14 @@ import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.xml.NodeSeq
 
 class ManageDocumentsConnector @Inject()(config: AppConfig, ws: WSClient, val metrics: Metrics)(implicit ec: ExecutionContext) extends HasMetrics {
 
-  def getUnloadingPermissionPdf(movementMessage: ResponseMovementMessage)(implicit hc: HeaderCarrier): Future[WSResponse] = {
+  def getUnloadingPermissionPdf(movementMessage: ResponseMovementMessage)(implicit hc: HeaderCarrier): Future[WSResponse] =
+    getUnloadingPermissionPdf(movementMessage.message)(hc)
+
+  def getUnloadingPermissionPdf(messageBody: NodeSeq)(implicit hc: HeaderCarrier): Future[WSResponse] = {
     val serviceUrl = s"${config.manageDocumentsUrl}/unloading-permission"
 
     val headers = hc.headers(Seq(Constants.XClientIdHeader, Constants.XRequestIdHeader)) ++ Seq(
@@ -44,7 +48,7 @@ class ManageDocumentsConnector @Inject()(config: AppConfig, ws: WSClient, val me
     withMetricsTimerResponse("manage-documents-get-unloading-permission-pdf") {
       ws.url(serviceUrl)
         .withHttpHeaders(headers: _*)
-        .post(movementMessage.message.toString)
+        .post(messageBody.toString)
     }
   }
 }

--- a/app/controllers/actions/AuthenticatedGetMessagesForReadActionProvider.scala
+++ b/app/controllers/actions/AuthenticatedGetMessagesForReadActionProvider.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import models.ArrivalId
+import models.MessageType
+import models.request.ArrivalsMessagesRequest
+import play.api.mvc.ActionBuilder
+import play.api.mvc.AnyContent
+import play.api.mvc.DefaultActionBuilder
+
+import javax.inject.Inject
+
+trait AuthenticatedGetMessagesForReadActionProvider {
+  def apply(arrivalId: ArrivalId, messageTypes: List[MessageType]): ActionBuilder[ArrivalsMessagesRequest, AnyContent]
+}
+
+class AuthenticatedGetMessagesForReadActionProviderImpl @Inject()(
+  authenticate: AuthenticateActionProvider,
+  getArrivalMessages: AuthenticatedGetMessagesActionProvider,
+  buildDefault: DefaultActionBuilder
+) extends AuthenticatedGetMessagesForReadActionProvider {
+
+  def apply(arrivalId: ArrivalId, messageTypes: List[MessageType]): ActionBuilder[ArrivalsMessagesRequest, AnyContent] =
+    buildDefault andThen authenticate() andThen getArrivalMessages(arrivalId, messageTypes)
+}

--- a/app/models/ArrivalMessages.scala
+++ b/app/models/ArrivalMessages.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+import models.MessageType._
+
+case class ArrivalMessages(
+  arrivalId: ArrivalId,
+  eoriNumber: String,
+  messages: List[MovementMessage]
+)
+
+object ArrivalMessages {
+
+  implicit val readsArrivalMessages: Reads[ArrivalMessages] =
+    (
+      (__ \ "_id").read[ArrivalId] and
+        (__ \ "eoriNumber").read[String] and
+        (__ \ "messages").read[List[MovementMessage]]
+    )(ArrivalMessages.apply _)
+
+}

--- a/app/models/request/ArrivalsMessagesRequest.scala
+++ b/app/models/request/ArrivalsMessagesRequest.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.request
+
+import models.ArrivalId
+import models.ChannelType
+import models.MovementMessage
+import play.api.mvc.WrappedRequest
+
+case class ArrivalsMessagesRequest[A](request: AuthenticatedRequest[A], arrivalId: ArrivalId, channel: ChannelType, messages: List[MovementMessage])
+    extends WrappedRequest[A](request)

--- a/app/models/request/AuthenticatedRequest.scala
+++ b/app/models/request/AuthenticatedRequest.scala
@@ -18,6 +18,7 @@ package models.request
 
 import cats.data.Ior
 import models.Arrival
+import models.ArrivalMessages
 import models.ArrivalWithoutMessages
 import models.ChannelType
 import models.EORINumber
@@ -40,4 +41,8 @@ case class AuthenticatedRequest[A](request: Request[A], channel: ChannelType, en
 
   def hasMatchingEnrolmentId(arrival: ArrivalWithoutMessages): Boolean =
     matchesEnrolmentId(arrival.eoriNumber)
+
+  def hasMatchingEnrolmentId(arrival: ArrivalMessages): Boolean =
+    matchesEnrolmentId(arrival.eoriNumber)
+
 }

--- a/app/repositories/ArrivalMovementRepository.scala
+++ b/app/repositories/ArrivalMovementRepository.scala
@@ -273,6 +273,34 @@ class ArrivalMovementRepository @Inject()(
           .headOption
     }
 
+  def getMessagesOfType(arrivalId: ArrivalId, channelFilter: ChannelType, messageTypes: List[MessageType]): Future[Option[ArrivalMessages]] =
+    collection.flatMap {
+      c =>
+        c.aggregateWith[ArrivalMessages](allowDiskUse = true) {
+            _ =>
+              import c.aggregationFramework._
+
+              val initialFilter: PipelineOperator = Match(Json.obj("_id" -> arrivalId, "channel" -> channelFilter))
+
+              val project = List[PipelineOperator](Project(Json.obj("_id" -> 1, "eoriNumber" -> 1, "messages" -> 1)))
+
+              // Filters out the messages with message types we don't care about, meaning that if we have a
+              // match for the arrival id and the eori number, but not a message type match,
+              // we then get an empty list which indiates an arrival that doesn't have the required message
+              // types as of yet, but would otherwise be valid
+              val inFilter       = Json.obj("$in"     -> Json.arr("$$message.messageType", messageTypes.map(_.code).toSeq))
+              val messagesFilter = Json.obj("$filter" -> Json.obj("input" -> "$messages", "as" -> "message", "cond" -> inFilter))
+
+              val secondaryFilter = List[PipelineOperator](AddFields(Json.obj("messages" -> messagesFilter)))
+
+              val transformations = project ++ secondaryFilter
+
+              (initialFilter, transformations)
+
+          }
+          .headOption
+    }
+
   def fetchAllArrivals(
     enrolmentId: Ior[TURN, EORINumber],
     channelFilter: ChannelType,

--- a/test/controllers/actions/AuthenticatedGetMessagesForReadActionProviderSpec.scala
+++ b/test/controllers/actions/AuthenticatedGetMessagesForReadActionProviderSpec.scala
@@ -1,0 +1,443 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import generators.ModelGenerators
+import models.ChannelType.web
+import models.ChannelType.api
+import models.ArrivalId
+import models.ArrivalMessages
+import org.mockito.ArgumentMatchers.{eq => eqTo, _}
+import org.mockito.Mockito.when
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalatest.OptionValues
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc._
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import repositories.ArrivalMovementRepository
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.auth.core.Enrolment
+import uk.gov.hmrc.auth.core.EnrolmentIdentifier
+import uk.gov.hmrc.auth.core.Enrolments
+
+import scala.concurrent.Future
+
+class AuthenticatedGetMessagesActionProviderSpec
+    extends AnyFreeSpec
+    with Matchers
+    with MockitoSugar
+    with ScalaCheckPropertyChecks
+    with ModelGenerators
+    with OptionValues {
+
+  def fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("", "").withHeaders("channel" -> web.toString())
+
+  class Harness(authAndGet: AuthenticatedGetMessagesForReadActionProvider) {
+
+    def get(arrivalId: ArrivalId): Action[AnyContent] = authAndGet(arrivalId, List()) {
+      request =>
+        Results.Ok(request.arrivalId.toString)
+    }
+  }
+
+  "authenticated get messages for read" - {
+
+    "when given valid enrolments" - {
+
+      val eoriNumber = "123"
+
+      val validEnrolments: Enrolments = Enrolments(
+        Set(
+          Enrolment(
+            key = "IR-SA",
+            identifiers = Seq(
+              EnrolmentIdentifier(
+                "UTR",
+                "123"
+              )
+            ),
+            state = "Activated"
+          ),
+          Enrolment(
+            key = "HMCE-NCTS-ORG",
+            identifiers = Seq(
+              EnrolmentIdentifier(
+                "VATRegNoTURN",
+                eoriNumber
+              )
+            ),
+            state = "Activated"
+          )
+        )
+      )
+
+      "must get an ArrivalMessages when the arrival exists, has messages, and its EORI matches the user's" in {
+
+        val arrival = arbitrary[ArrivalMessages].sample.value copy (eoriNumber = eoriNumber)
+
+        val mockAuthConnector: AuthConnector = mock[AuthConnector]
+        val mockArrivalMovementRepository    = mock[ArrivalMovementRepository]
+
+        when(mockAuthConnector.authorise[Enrolments](any(), any())(any(), any()))
+          .thenReturn(Future.successful(validEnrolments))
+        when(mockArrivalMovementRepository.getMessagesOfType(any(), any(), any())) thenReturn Future.successful(Some(arrival))
+
+        val application = new GuiceApplicationBuilder()
+          .overrides(
+            bind[ArrivalMovementRepository].toInstance(mockArrivalMovementRepository),
+            bind[AuthConnector].toInstance(mockAuthConnector),
+          )
+          .build()
+
+        running(application) {
+          val actionProvider = application.injector.instanceOf[AuthenticatedGetMessagesForReadActionProvider]
+
+          val controller = new Harness(actionProvider)
+          val result     = controller.get(arrival.arrivalId)(fakeRequest)
+
+          status(result) mustBe OK
+          contentAsString(result) mustBe arrival.arrivalId.toString
+        }
+      }
+
+      "must return Not Found when the arrival exists and shares the same channel, but does not have any messages" in {
+
+        val arrival = arbitrary[ArrivalMessages].sample.value copy (eoriNumber = eoriNumber, messages = List())
+
+        val arrivalId = arbitrary[ArrivalId].sample.value
+
+        val mockAuthConnector: AuthConnector = mock[AuthConnector]
+        val mockArrivalMovementRepository    = mock[ArrivalMovementRepository]
+
+        when(mockAuthConnector.authorise[Enrolments](any(), any())(any(), any()))
+          .thenReturn(Future.successful(validEnrolments))
+        when(mockArrivalMovementRepository.getMessagesOfType(any(), eqTo(api), any())).thenReturn(Future.successful(Some(arrival)))
+
+        val application = new GuiceApplicationBuilder()
+          .overrides(
+            bind[ArrivalMovementRepository].toInstance(mockArrivalMovementRepository),
+            bind[AuthConnector].toInstance(mockAuthConnector)
+          )
+          .build()
+
+        running(application) {
+          val actionProvider = application.injector.instanceOf[AuthenticatedGetMessagesForReadActionProvider]
+
+          val fakeAPIRequest = fakeRequest.withHeaders("channel" -> "api")
+
+          val controller = new Harness(actionProvider)
+          val result     = controller.get(arrivalId)(fakeAPIRequest)
+
+          status(result) mustBe NOT_FOUND
+        }
+      }
+
+      "must return Not Found when the arrival exists and its EORI does not match the user's" in {
+
+        val arrival = arbitrary[ArrivalMessages].sample.value copy (eoriNumber = "invalid EORI number")
+
+        val mockAuthConnector: AuthConnector = mock[AuthConnector]
+        val mockArrivalMovementRepository    = mock[ArrivalMovementRepository]
+
+        when(mockAuthConnector.authorise[Enrolments](any(), any())(any(), any()))
+          .thenReturn(Future.successful(validEnrolments))
+        when(mockArrivalMovementRepository.getMessagesOfType(any(), any(), any())) thenReturn Future.successful(Some(arrival))
+
+        val application = new GuiceApplicationBuilder()
+          .overrides(
+            bind[ArrivalMovementRepository].toInstance(mockArrivalMovementRepository),
+            bind[AuthConnector].toInstance(mockAuthConnector)
+          )
+          .build()
+
+        running(application) {
+          val actionProvider = application.injector.instanceOf[AuthenticatedGetMessagesForReadActionProvider]
+
+          val controller = new Harness(actionProvider)
+          val result     = controller.get(arrival.arrivalId)(fakeRequest)
+
+          status(result) mustBe NOT_FOUND
+        }
+      }
+
+      "must return Not Found when the arrival does not exist" in {
+
+        val arrivalId = arbitrary[ArrivalId].sample.value
+
+        val mockAuthConnector: AuthConnector = mock[AuthConnector]
+        val mockArrivalMovementRepository    = mock[ArrivalMovementRepository]
+
+        when(mockAuthConnector.authorise[Enrolments](any(), any())(any(), any()))
+          .thenReturn(Future.successful(validEnrolments))
+        when(mockArrivalMovementRepository.getMessagesOfType(any(), any(), any())) thenReturn Future.successful(None)
+
+        val application = new GuiceApplicationBuilder()
+          .overrides(
+            bind[ArrivalMovementRepository].toInstance(mockArrivalMovementRepository),
+            bind[AuthConnector].toInstance(mockAuthConnector)
+          )
+          .build()
+
+        running(application) {
+          val actionProvider = application.injector.instanceOf[AuthenticatedGetMessagesForReadActionProvider]
+
+          val controller = new Harness(actionProvider)
+          val result     = controller.get(arrivalId)(fakeRequest)
+
+          status(result) mustBe NOT_FOUND
+        }
+      }
+
+      "must return Not Found when the arrival exists but does not share the channel" in {
+
+        val arrivalId = arbitrary[ArrivalId].sample.value
+
+        val mockAuthConnector: AuthConnector = mock[AuthConnector]
+        val mockArrivalMovementRepository    = mock[ArrivalMovementRepository]
+
+        when(mockAuthConnector.authorise[Enrolments](any(), any())(any(), any()))
+          .thenReturn(Future.successful(validEnrolments))
+        when(mockArrivalMovementRepository.getMessagesOfType(any(), eqTo(api), any())).thenReturn(Future.successful(None))
+
+        val application = new GuiceApplicationBuilder()
+          .overrides(
+            bind[ArrivalMovementRepository].toInstance(mockArrivalMovementRepository),
+            bind[AuthConnector].toInstance(mockAuthConnector)
+          )
+          .build()
+
+        running(application) {
+          val actionProvider = application.injector.instanceOf[AuthenticatedGetMessagesForReadActionProvider]
+
+          val fakeAPIRequest = fakeRequest.withHeaders("channel" -> api.toString())
+
+          val controller = new Harness(actionProvider)
+          val result     = controller.get(arrivalId)(fakeAPIRequest)
+
+          status(result) mustBe NOT_FOUND
+        }
+      }
+
+      "must return InternalServerError when repository has issues" in {
+        val arrivalId = arbitrary[ArrivalId].sample.value
+
+        val mockAuthConnector: AuthConnector = mock[AuthConnector]
+        val mockArrivalMovementRepository    = mock[ArrivalMovementRepository]
+
+        when(mockAuthConnector.authorise[Enrolments](any(), any())(any(), any()))
+          .thenReturn(Future.successful(validEnrolments))
+        when(mockArrivalMovementRepository.getMessagesOfType(any(), any(), any())) thenReturn Future.failed(new Exception)
+
+        val application = new GuiceApplicationBuilder()
+          .overrides(
+            bind[ArrivalMovementRepository].toInstance(mockArrivalMovementRepository),
+            bind[AuthConnector].toInstance(mockAuthConnector)
+          )
+          .build()
+
+        running(application) {
+          val actionProvider = application.injector.instanceOf[AuthenticatedGetMessagesForReadActionProvider]
+
+          val controller = new Harness(actionProvider)
+          val result     = controller.get(arrivalId)(fakeRequest)
+
+          status(result) mustBe INTERNAL_SERVER_ERROR
+        }
+      }
+    }
+
+    "when given invalid enrolments" - {
+
+      val invalidEnrolments = Enrolments(
+        Set(
+          Enrolment(
+            key = "IR-SA",
+            identifiers = Seq(
+              EnrolmentIdentifier(
+                "UTR",
+                "123"
+              )
+            ),
+            state = "Activated"
+          )
+        )
+      )
+
+      "must return Forbidden" in {
+
+        val arrivalId = arbitrary[ArrivalId].sample.value
+
+        val mockAuthConnector: AuthConnector = mock[AuthConnector]
+
+        when(mockAuthConnector.authorise[Enrolments](any(), any())(any(), any()))
+          .thenReturn(Future.successful(invalidEnrolments))
+
+        val application = new GuiceApplicationBuilder()
+          .overrides(
+            bind[AuthConnector].toInstance(mockAuthConnector)
+          )
+          .build()
+
+        running(application) {
+          val actionProvider = application.injector.instanceOf[AuthenticatedGetMessagesForReadActionProvider]
+
+          val controller = new Harness(actionProvider)
+          val result     = controller.get(arrivalId)(fakeRequest)
+
+          status(result) mustBe FORBIDDEN
+        }
+      }
+    }
+
+    "when channel header is missing" - {
+
+      val eoriNumber = "EORI"
+
+      val validEnrolments: Enrolments = Enrolments(
+        Set(
+          Enrolment(
+            key = "IR-SA",
+            identifiers = Seq(
+              EnrolmentIdentifier(
+                "UTR",
+                "123"
+              )
+            ),
+            state = "Activated"
+          ),
+          Enrolment(
+            key = "HMCE-NCTS-ORG",
+            identifiers = Seq(
+              EnrolmentIdentifier(
+                "VATRegNoTURN",
+                eoriNumber
+              )
+            ),
+            state = "Activated"
+          )
+        )
+      )
+
+      "must return BadRequest" in {
+
+        val arrivalId = arbitrary[ArrivalId].sample.value
+
+        val mockAuthConnector = mock[AuthConnector]
+
+        when(mockAuthConnector.authorise[Enrolments](any(), any())(any(), any()))
+          .thenReturn(Future.successful(validEnrolments))
+
+        val application = new GuiceApplicationBuilder()
+          .overrides(
+            bind[AuthConnector].toInstance(mockAuthConnector)
+          )
+          .build()
+
+        running(application) {
+          val actionProvider = application.injector.instanceOf[AuthenticatedGetMessagesForReadActionProvider]
+
+          val controller = new Harness(actionProvider)
+          val result     = controller.get(arrivalId)(fakeRequest.withHeaders(Headers.create()))
+
+          status(result) mustEqual BAD_REQUEST
+          contentAsString(result) mustEqual "Missing channel header or incorrect value specified in channel header"
+        }
+      }
+    }
+
+    "when channel header contains invalid value" - {
+
+      val eoriNumber = "EORI"
+
+      val validEnrolments: Enrolments = Enrolments(
+        Set(
+          Enrolment(
+            key = "IR-SA",
+            identifiers = Seq(
+              EnrolmentIdentifier(
+                "UTR",
+                "123"
+              )
+            ),
+            state = "Activated"
+          ),
+          Enrolment(
+            key = "HMCE-NCTS-ORG",
+            identifiers = Seq(
+              EnrolmentIdentifier(
+                "VATRegNoTURN",
+                eoriNumber
+              )
+            ),
+            state = "Activated"
+          )
+        )
+      )
+
+      "must return BadRequest" in {
+
+        val arrivalId = arbitrary[ArrivalId].sample.value
+
+        val mockAuthConnector = mock[AuthConnector]
+
+        when(mockAuthConnector.authorise[Enrolments](any(), any())(any(), any()))
+          .thenReturn(Future.successful(validEnrolments))
+
+        val application = new GuiceApplicationBuilder()
+          .overrides(
+            bind[AuthConnector].toInstance(mockAuthConnector)
+          )
+          .build()
+
+        running(application) {
+          val actionProvider = application.injector.instanceOf[AuthenticatedGetMessagesForReadActionProvider]
+
+          val controller = new Harness(actionProvider)
+          val result     = controller.get(arrivalId)(fakeRequest.withHeaders("channel" -> "web2"))
+
+          status(result) mustEqual BAD_REQUEST
+          contentAsString(result) mustEqual "Missing channel header or incorrect value specified in channel header"
+        }
+      }
+
+      "must return BadRequest if passed authentication" in {
+        val arrivalId = arbitrary[ArrivalId].sample.value
+        val application = new GuiceApplicationBuilder()
+          .overrides(
+            bind[AuthenticateActionProvider].to[FakeAuthenticateActionProvider]
+          )
+          .build()
+
+        running(application) {
+          val actionProvider = application.injector.instanceOf[AuthenticatedGetMessagesForReadActionProvider]
+
+          val controller = new Harness(actionProvider)
+          val result     = controller.get(arrivalId)(fakeRequest.withHeaders("channel" -> "web2"))
+
+          status(result) mustEqual BAD_REQUEST
+          contentAsString(result) mustEqual "Missing channel header or incorrect value specified in channel header"
+        }
+      }
+    }
+  }
+}

--- a/test/generators/ModelGenerators.scala
+++ b/test/generators/ModelGenerators.scala
@@ -29,6 +29,7 @@ import connectors.MessageConnector.EisSubmissionResult.UnexpectedHttpResponse
 import connectors.MessageConnector.EisSubmissionResult.VirusFoundOrInvalidToken
 import models.Arrival
 import models.ArrivalId
+import models.ArrivalMessages
 import models.ArrivalPutUpdate
 import models.ArrivalStatus
 import models.ArrivalUpdate
@@ -52,6 +53,7 @@ import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import uk.gov.hmrc.http.UpstreamErrorResponse
+
 import java.time._
 
 trait ModelGenerators extends BaseGenerators with JavaTimeGenerators {
@@ -176,6 +178,15 @@ trait ModelGenerators extends BaseGenerators with JavaTimeGenerators {
       }
     }.arbitrary
 
+  val genArrivalMessagesWithSpecificEori: Gen[ArrivalMessages] =
+    Arbitrary {
+      for {
+        arrivalMessages <- Arbitrary.arbitrary[ArrivalMessages]
+      } yield {
+        arrivalMessages.copy(eoriNumber = "eori")
+      }
+    }.arbitrary
+
   implicit lazy val arbitraryMovementReferenceNumber: Arbitrary[MovementReferenceNumber] =
     Arbitrary {
       for {
@@ -283,4 +294,14 @@ trait ModelGenerators extends BaseGenerators with JavaTimeGenerators {
         messageMetaData         <- arbitrary[Seq[MessageMetaData]]
       } yield ResponseArrival(arrivalId, location, messagesLocation, movementReferenceNumber, status, created, updated, messageMetaData)
     )
+
+  implicit lazy val arbitaryArrivalMessages: Arbitrary[ArrivalMessages] =
+    Arbitrary(
+      for {
+        arrivalId <- arbitrary[ArrivalId]
+        eori      <- arbitrary[String]
+        message   <- arbitrary[MovementMessageWithStatus]
+      } yield ArrivalMessages(arrivalId, eori, List(message))
+    )
+
 }


### PR DESCRIPTION
* Adds `getMessagesOfType` to `ArrivalMovementRepository` for retriving only messages and an EORI number
* Adds `AuthenticatedGetMessagesAction` and associated support for handling requests for specific message types
* Adds `ArrivalMessages` object to bundle messages, the EORI number and arrival ID
* Adds supporting tests

A similar PR will be made to the departure repo.