### PR TITLE
CTDA 1684: Add audit type and method for missing movements

### DIFF
--- a/app/audit/AuditService.scala
+++ b/app/audit/AuditService.scala
@@ -44,10 +44,19 @@ class AuditService @Inject()(auditConnector: AuditConnector, messageTranslation:
     auditConnector.sendExplicitAudit(messageResponse.auditType, details)
   }
 
-  def auditMissingMovementEvent(request: AuthenticatedRequest[_], arrivalId: ArrivalId): Unit = {
+  def auditNCTSRequestedMissingMovementEvent(messageResponse: MessageResponse, message: MovementMessage)(
+    implicit hc: HeaderCarrier): Unit = {
+    val details = Json.obj(
+      "messageResponseType" -> messageResponse.auditType,
+      "message" -> messageTranslation.translate(message.messageJson)
+    )
+    auditConnector.sendExplicitAudit(AuditType.NCTSRequestedMissingMovement, details)
+  }
+
+  def auditCustomerRequestedMissingMovementEvent(request: AuthenticatedRequest[_], arrivalId: ArrivalId): Unit = {
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
     val details                    = AuthenticatedAuditDetails(request.channel, request.enrolmentId, Json.obj("arrivalId" -> arrivalId))
-    auditConnector.sendExplicitAudit(AuditType.MissingMovementRequested, details)
+    auditConnector.sendExplicitAudit(AuditType.CustomerRequestedMissingMovement, details)
   }
 
   def authAudit(auditType: String, details: AuthenticationDetails)(implicit hc: HeaderCarrier): Unit =

--- a/app/audit/AuditService.scala
+++ b/app/audit/AuditService.scala
@@ -44,11 +44,12 @@ class AuditService @Inject()(auditConnector: AuditConnector, messageTranslation:
     auditConnector.sendExplicitAudit(messageResponse.auditType, details)
   }
 
-  def auditNCTSRequestedMissingMovementEvent(messageResponse: MessageResponse, message: MovementMessage)(
+  def auditNCTSRequestedMissingMovementEvent(arrivalId: ArrivalId, messageResponse: MessageResponse, message: MovementMessage)(
     implicit hc: HeaderCarrier): Unit = {
     val details = Json.obj(
+      "arrivalId"           -> arrivalId,
       "messageResponseType" -> messageResponse.auditType,
-      "message" -> messageTranslation.translate(message.messageJson)
+      "message"             -> messageTranslation.translate(message.messageJson)
     )
     auditConnector.sendExplicitAudit(AuditType.NCTSRequestedMissingMovement, details)
   }

--- a/app/audit/AuditService.scala
+++ b/app/audit/AuditService.scala
@@ -17,14 +17,17 @@
 package audit
 
 import cats.data.Ior
+import javax.inject.Inject
 import models._
+import models.request.AuthenticatedRequest
 import play.api.libs.json.Format.GenericFormat
+import play.api.libs.json.Json
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import utils.MessageTranslation
-import javax.inject.Inject
 
 import scala.concurrent.ExecutionContext
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
 class AuditService @Inject()(auditConnector: AuditConnector, messageTranslation: MessageTranslation)(implicit ec: ExecutionContext) {
 
@@ -39,6 +42,12 @@ class AuditService @Inject()(auditConnector: AuditConnector, messageTranslation:
     val json    = messageTranslation.translate(message.messageJson)
     val details = UnauthenticatedAuditDetails(channel, customerId, json)
     auditConnector.sendExplicitAudit(messageResponse.auditType, details)
+  }
+
+  def auditMissingMovementEvent(request: AuthenticatedRequest[_], arrivalId: ArrivalId): Unit = {
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
+    val details                    = AuthenticatedAuditDetails(request.channel, request.enrolmentId, Json.obj("arrivalId" -> arrivalId))
+    auditConnector.sendExplicitAudit(AuditType.MissingMovementRequested, details)
   }
 
   def authAudit(auditType: String, details: AuthenticationDetails)(implicit hc: HeaderCarrier): Unit =

--- a/app/audit/AuditType.scala
+++ b/app/audit/AuditType.scala
@@ -18,7 +18,8 @@ package audit
 
 object AuditType {
 
-  val MissingMovementRequested = "MissingMovementRequested"
+  val CustomerRequestedMissingMovement     = "CustomerRequestedMissingMovement"
+  val NCTSRequestedMissingMovement         = "NCTSRequestedMissingMovement"
 
   val ArrivalNotificationSubmitted         = "ArrivalNotificationSubmitted"
   val ArrivalNotificationReSubmitted       = "ArrivalNotificationReSubmitted"

--- a/app/audit/AuditType.scala
+++ b/app/audit/AuditType.scala
@@ -18,6 +18,8 @@ package audit
 
 object AuditType {
 
+  val MissingMovementRequested = "MissingMovementRequested"
+
   val ArrivalNotificationSubmitted         = "ArrivalNotificationSubmitted"
   val ArrivalNotificationReSubmitted       = "ArrivalNotificationReSubmitted"
   val GoodsReleased                        = "GoodsReleased"

--- a/app/audit/AuditType.scala
+++ b/app/audit/AuditType.scala
@@ -18,8 +18,8 @@ package audit
 
 object AuditType {
 
-  val CustomerRequestedMissingMovement     = "CustomerRequestedMissingMovement"
-  val NCTSRequestedMissingMovement         = "NCTSRequestedMissingMovement"
+  val CustomerRequestedMissingMovement = "CustomerRequestedMissingMovement"
+  val NCTSRequestedMissingMovement     = "NCTSRequestedMissingMovement"
 
   val ArrivalNotificationSubmitted         = "ArrivalNotificationSubmitted"
   val ArrivalNotificationReSubmitted       = "ArrivalNotificationReSubmitted"

--- a/app/controllers/actions/AuthenticatedGetArrivalWithoutMessagesActionProvider.scala
+++ b/app/controllers/actions/AuthenticatedGetArrivalWithoutMessagesActionProvider.scala
@@ -64,7 +64,7 @@ private[actions] class AuthenticatedGetArrivalWithoutMessagesAction(
               logger.warn("Attempt to retrieve an arrival for another EORI")
               Left(NotFound)
             case None =>
-              auditService.auditMissingMovementEvent(request, arrivalId)
+              auditService.auditCustomerRequestedMissingMovementEvent(request, arrivalId)
               Left(NotFound)
           }
           .recover {

--- a/app/controllers/actions/AuthenticatedGetArrivalWithoutMessagesActionProvider.scala
+++ b/app/controllers/actions/AuthenticatedGetArrivalWithoutMessagesActionProvider.scala
@@ -30,18 +30,21 @@ import repositories.ArrivalMovementRepository
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import audit.AuditService
 
 private[actions] class AuthenticatedGetArrivalWithoutMessagesActionProvider @Inject()(
-  repository: ArrivalMovementRepository
+  repository: ArrivalMovementRepository,
+  auditService: AuditService
 )(implicit ec: ExecutionContext) {
 
   def apply(arrivalId: ArrivalId): ActionRefiner[AuthenticatedRequest, ArrivalWithoutMessagesRequest] =
-    new AuthenticatedGetArrivalWithoutMessagesAction(arrivalId, repository)
+    new AuthenticatedGetArrivalWithoutMessagesAction(arrivalId, repository, auditService)
 }
 
 private[actions] class AuthenticatedGetArrivalWithoutMessagesAction(
   arrivalId: ArrivalId,
-  repository: ArrivalMovementRepository
+  repository: ArrivalMovementRepository,
+  auditService: AuditService
 )(implicit val executionContext: ExecutionContext)
     extends ActionRefiner[AuthenticatedRequest, ArrivalWithoutMessagesRequest]
     with Logging {
@@ -61,6 +64,7 @@ private[actions] class AuthenticatedGetArrivalWithoutMessagesAction(
               logger.warn("Attempt to retrieve an arrival for another EORI")
               Left(NotFound)
             case None =>
+              auditService.auditMissingMovementEvent(request, arrivalId)
               Left(NotFound)
           }
           .recover {

--- a/app/controllers/actions/AuthenticatedGetMessagesActionProvider.scala
+++ b/app/controllers/actions/AuthenticatedGetMessagesActionProvider.scala
@@ -70,7 +70,7 @@ private[actions] class AuthenticatedGetMessagesAction(
               logger.warn("Attempt to retrieve an arrival for another EORI")
               Left(NotFound)
             case None =>
-              auditService.auditMissingMovementEvent(request, arrivalId)
+              auditService.auditCustomerRequestedMissingMovementEvent(request, arrivalId)
               Left(NotFound)
           }
           .recover {

--- a/app/controllers/actions/AuthenticatedGetMessagesActionProvider.scala
+++ b/app/controllers/actions/AuthenticatedGetMessagesActionProvider.scala
@@ -31,20 +31,23 @@ import repositories.ArrivalMovementRepository
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import audit.AuditService
 
 private[actions] class AuthenticatedGetMessagesActionProvider @Inject()(
-  repository: ArrivalMovementRepository
+  repository: ArrivalMovementRepository,
+  auditService: AuditService
 )(implicit ec: ExecutionContext) {
 
   def apply(arrivalId: ArrivalId, messageTypes: List[MessageType]): ActionRefiner[AuthenticatedRequest, ArrivalsMessagesRequest] =
-    new AuthenticatedGetMessagesAction(arrivalId, repository, messageTypes)
+    new AuthenticatedGetMessagesAction(arrivalId, repository, messageTypes, auditService)
 
 }
 
 private[actions] class AuthenticatedGetMessagesAction(
   arrivalId: ArrivalId,
   repository: ArrivalMovementRepository,
-  messageTypes: List[MessageType]
+  messageTypes: List[MessageType],
+  auditService: AuditService
 )(implicit val executionContext: ExecutionContext)
     extends ActionRefiner[AuthenticatedRequest, ArrivalsMessagesRequest]
     with Logging {
@@ -67,6 +70,7 @@ private[actions] class AuthenticatedGetMessagesAction(
               logger.warn("Attempt to retrieve an arrival for another EORI")
               Left(NotFound)
             case None =>
+              auditService.auditMissingMovementEvent(request, arrivalId)
               Left(NotFound)
           }
           .recover {

--- a/app/models/ChannelType.scala
+++ b/app/models/ChannelType.scala
@@ -19,8 +19,8 @@ package models
 sealed trait ChannelType
 
 object ChannelType extends Enumerable.Implicits {
-  case object web     extends ChannelType
-  case object api     extends ChannelType
+  case object web extends ChannelType
+  case object api extends ChannelType
 
   val values: Seq[ChannelType] = Seq(web, api)
 

--- a/app/models/ChannelType.scala
+++ b/app/models/ChannelType.scala
@@ -21,7 +21,6 @@ sealed trait ChannelType
 object ChannelType extends Enumerable.Implicits {
   case object web     extends ChannelType
   case object api     extends ChannelType
-  case object deleted extends ChannelType
 
   val values: Seq[ChannelType] = Seq(web, api)
 

--- a/app/services/GetArrivalService.scala
+++ b/app/services/GetArrivalService.scala
@@ -25,7 +25,6 @@ import models.ArrivalWithoutMessages
 import models.MessageResponse
 import models.MovementMessage
 import models.SubmissionState
-import models.ChannelType.deleted
 import repositories.ArrivalMovementRepository
 import uk.gov.hmrc.http.HeaderCarrier
 import javax.inject.Inject
@@ -51,12 +50,8 @@ class GetArrivalService @Inject()(repository: ArrivalMovementRepository, auditSe
   def getArrivalAndAudit(arrivalId: ArrivalId, messageResponse: MessageResponse, movementMessage: MovementMessage)(
     implicit hc: HeaderCarrier): EitherT[Future, SubmissionState, ArrivalWithoutMessages] =
     EitherT(
-      getArrivalWithoutMessagesById(arrivalId).map {
-        _.left.map {
-          submissionState =>
-            auditService.auditNCTSMessages(deleted, "deleted", messageResponse, movementMessage)
-            submissionState
-        }
-      }
-    )
+      getArrivalWithoutMessagesById(arrivalId)
+    ).leftSemiflatTap { _ =>
+      Future.successful(auditService.auditNCTSRequestedMissingMovementEvent(messageResponse, movementMessage))
+    }
 }

--- a/app/services/GetArrivalService.scala
+++ b/app/services/GetArrivalService.scala
@@ -51,7 +51,8 @@ class GetArrivalService @Inject()(repository: ArrivalMovementRepository, auditSe
     implicit hc: HeaderCarrier): EitherT[Future, SubmissionState, ArrivalWithoutMessages] =
     EitherT(
       getArrivalWithoutMessagesById(arrivalId)
-    ).leftSemiflatTap { _ =>
-      Future.successful(auditService.auditNCTSRequestedMissingMovementEvent(messageResponse, movementMessage))
+    ).leftSemiflatTap {
+      _ =>
+        Future.successful(auditService.auditNCTSRequestedMissingMovementEvent(arrivalId, messageResponse, movementMessage))
     }
 }

--- a/test/audit/AuditServiceSpec.scala
+++ b/test/audit/AuditServiceSpec.scala
@@ -199,14 +199,16 @@ class AuditServiceSpec extends SpecBase with ScalaCheckPropertyChecks with Befor
       val messageResponse = UnloadingPermissionResponse
       val requestXml      = <xml>test</xml>
       val movementMessage = MovementMessageWithoutStatus(MessageId(1), LocalDateTime.now, MessageType.UnloadingPermission, requestXml, 1)
+      val arrivalId       = ArrivalId(0)
       val expectedDetails = Json.obj(
+        "arrivalId"           -> arrivalId,
         "messageResponseType" -> messageResponse.auditType,
-        "message" -> movementMessage.messageJson
+        "message"             -> movementMessage.messageJson
       )
 
       running(application) {
         val auditService = application.injector.instanceOf[AuditService]
-        auditService.auditNCTSRequestedMissingMovementEvent(messageResponse, movementMessage)
+        auditService.auditNCTSRequestedMissingMovementEvent(arrivalId, messageResponse, movementMessage)
 
         verify(mockAuditConnector, times(1)).sendExplicitAudit(eqTo(AuditType.NCTSRequestedMissingMovement), eqTo(expectedDetails))(any(), any())
         reset(mockAuditConnector)

--- a/test/controllers/actions/AuthenticatedGetArrivalWithoutMessagesForReadActionProviderSpec.scala
+++ b/test/controllers/actions/AuthenticatedGetArrivalWithoutMessagesForReadActionProviderSpec.scala
@@ -16,6 +16,7 @@
 
 package controllers.actions
 
+import audit.AuditService
 import generators.ModelGenerators
 import migrations.MigrationRunner
 import migrations.MigrationRunnerImpl
@@ -23,6 +24,7 @@ import models.ChannelType.web
 import models.ChannelType.api
 import models.ArrivalId
 import models.ArrivalWithoutMessages
+import models.request.AuthenticatedRequest
 import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
@@ -45,8 +47,6 @@ import uk.gov.hmrc.auth.core.EnrolmentIdentifier
 import uk.gov.hmrc.auth.core.Enrolments
 
 import scala.concurrent.Future
-import audit.AuditService
-import models.request.AuthenticatedRequest
 
 class AuthenticatedGetArrivalWithoutMessagesForReadActionProviderSpec
     extends AnyFreeSpec

--- a/test/controllers/actions/AuthenticatedGetArrivalWithoutMessagesForReadActionProviderSpec.scala
+++ b/test/controllers/actions/AuthenticatedGetArrivalWithoutMessagesForReadActionProviderSpec.scala
@@ -184,7 +184,7 @@ class AuthenticatedGetArrivalWithoutMessagesForReadActionProviderSpec
           val result     = controller.get(arrivalId)(fakeRequest)
 
           status(result) mustBe NOT_FOUND
-          verify(mockAuditService, times(1)).auditMissingMovementEvent(any[AuthenticatedRequest[_]], eqTo(arrivalId))
+          verify(mockAuditService, times(1)).auditCustomerRequestedMissingMovementEvent(any[AuthenticatedRequest[_]], eqTo(arrivalId))
         }
       }
 

--- a/test/controllers/actions/AuthenticatedGetArrivalWithoutMessagesForWriteActionProviderSpec.scala
+++ b/test/controllers/actions/AuthenticatedGetArrivalWithoutMessagesForWriteActionProviderSpec.scala
@@ -206,7 +206,7 @@ class AuthenticatedGetArrivalWithoutMessagesForWriteActionProviderSpec
           status(result) mustBe NOT_FOUND
           verify(mockLockRepository, times(1)).lock(eqTo(arrivalId))
           verify(mockLockRepository, times(1)).unlock(eqTo(arrivalId))
-          verify(mockAuditService, times(1)).auditMissingMovementEvent(any[AuthenticatedRequest[_]], eqTo(arrivalId))
+          verify(mockAuditService, times(1)).auditCustomerRequestedMissingMovementEvent(any[AuthenticatedRequest[_]], eqTo(arrivalId))
         }
       }
 

--- a/test/services/GetArrivalServiceSpec.scala
+++ b/test/services/GetArrivalServiceSpec.scala
@@ -122,7 +122,7 @@ class GetArrivalServiceSpec extends SpecBase with ModelGenerators with ScalaChec
           val result = service.getArrivalAndAudit(ArrivalId(0), messageResponse, movementMessage).value.futureValue
 
           result.left.value mustBe an[ArrivalNotFoundError]
-          verify(mockAuditService, times(1)).auditNCTSRequestedMissingMovementEvent(any(), any())(any())
+          verify(mockAuditService, times(1)).auditNCTSRequestedMissingMovementEvent(eqTo(messageResponse), eqTo(movementMessage))(any())
           reset(mockAuditService)
         }
       }


### PR DESCRIPTION
If an arrival ID does not return a movement, audit it.

(Not a huge fan of the name of the audit type, so open to suggestions)

Also see https://github.com/hmrc/transits-movements-trader-at-departure/pull/152