### PR TITLE
CTDA-1935: Drop and recreate the TTL index whenever the TTL is updated

### DIFF
--- a/app/repositories/ArrivalMovementRepository.scala
+++ b/app/repositories/ArrivalMovementRepository.scala
@@ -560,7 +560,7 @@ class ArrivalMovementRepository @Inject()(
         val indexToDrop = indexes
           .filter(_.name.contains(lastUpdatedIndexName))
           .filter(x => x.expireAfterSeconds.map(_ != appConfig.cacheTtl).getOrElse(false))
-          .get(0)
+          .headOption
         indexToDrop match {
           case Some(index) =>
             val ttl = index.expireAfterSeconds.map(x => s"$x seconds").getOrElse("unset")

--- a/app/repositories/ArrivalMovementRepository.scala
+++ b/app/repositories/ArrivalMovementRepository.scala
@@ -103,7 +103,7 @@ class ArrivalMovementRepository @Inject()(
 
   private lazy val lastUpdatedIndex: Aux[BSONSerializationPack.type] = IndexUtils.index(
     key = Seq(lastUpdatedKey(IndexType.Ascending)),
-    name = Some("last-updated-index"),
+    name = Some(lastUpdatedIndexName),
     options = BSONDocument("expireAfterSeconds" -> appConfig.cacheTtl)
   )
 
@@ -122,8 +122,8 @@ class ArrivalMovementRepository @Inject()(
     name = Some("fetch-all-with-date-filter-index")
   )
 
-  private lazy val oldLastUpdatedIndexName = "last-updated-index-6m"
-  private lazy val collectionName          = ArrivalMovementRepository.collectionName
+  private lazy val lastUpdatedIndexName = "last-updated-index"
+  private lazy val collectionName       = ArrivalMovementRepository.collectionName
 
   def bulkInsert(arrivals: Seq[Arrival]): Future[Unit] =
     collection.flatMap {
@@ -557,18 +557,23 @@ class ArrivalMovementRepository @Inject()(
   private def dropLastUpdatedIndex(collection: JSONCollection): Future[Boolean] =
     collection.indexesManager.list.flatMap {
       indexes =>
-        if (indexes.exists(_.name.contains(oldLastUpdatedIndexName))) {
+        val indexToDrop = indexes
+          .filter(_.name.contains(lastUpdatedIndexName))
+          .filter(x => x.expireAfterSeconds.map(_ != appConfig.cacheTtl).getOrElse(false))
+          .get(0)
+        indexToDrop match {
+          case Some(index) =>
+            val ttl = index.expireAfterSeconds.map(x => s"$x seconds").getOrElse("unset")
+            logger.warn(s"Dropping $lastUpdatedIndexName index with TTL $ttl")
 
-          logger.warn(s"Dropping $oldLastUpdatedIndexName index")
-
-          collection.indexesManager
-            .drop(oldLastUpdatedIndexName)
-            .map(
-              _ => true
-            )
-        } else {
-          logger.info(s"$oldLastUpdatedIndexName does not exist or has already been dropped")
-          Future.successful(true)
+            collection.indexesManager
+              .drop(lastUpdatedIndexName)
+              .map(
+                _ => true
+              )
+          case None =>
+            logger.info(s"$lastUpdatedIndexName does not exist or is currently valid")
+            Future.successful(true)
         }
     }
 

--- a/app/repositories/ArrivalMovementRepository.scala
+++ b/app/repositories/ArrivalMovementRepository.scala
@@ -123,7 +123,7 @@ class ArrivalMovementRepository @Inject()(
   )
 
   private lazy val lastUpdatedIndexName = "last-updated-index"
-  private lazy val collectionName       = ArrivalMovementRepository.collectionName
+  lazy val collectionName               = ArrivalMovementRepository.collectionName
 
   def bulkInsert(arrivals: Seq[Arrival]): Future[Unit] =
     collection.flatMap {

--- a/it/repositories/ArrivalMovementRepositorySpec.scala
+++ b/it/repositories/ArrivalMovementRepositorySpec.scala
@@ -18,12 +18,14 @@ package repositories
 
 import akka.Done
 import akka.actor.ActorSystem
+import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.TestSink
 import base._
 import cats.data.Chain
 import cats.data.Ior
 import cats.data.NonEmptyList
+import com.kenshoo.play.metrics.Metrics
 import config.AppConfig
 import controllers.routes
 import models.ChannelType.api
@@ -39,17 +41,25 @@ import org.scalatest.exceptions.StackDepthException
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.TestSuiteMixin
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.Application
+import play.api.Configuration
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.JsObject
 import play.api.libs.json.Json
 import play.api.test.Helpers.running
+import play.modules.reactivemongo.ReactiveMongoApi
+import reactivemongo.api.indexes.Index
 import reactivemongo.api.indexes.IndexType
 import reactivemongo.play.json.collection.Helpers.idWrites
 import reactivemongo.play.json.collection.JSONCollection
 import utils.Format
 
 import java.time._
+import scala.concurrent.duration._
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.reflect.ClassTag
@@ -57,7 +67,8 @@ import scala.util.Failure
 import scala.util.Success
 import scala.xml.NodeSeq
 
-class ArrivalMovementRepositorySpec extends ItSpecBase with MongoSuite with ScalaFutures with TestSuiteMixin with MongoDateTimeFormats with BeforeAndAfterEach {
+
+class ArrivalMovementRepositorySpec extends ItSpecBase with MongoSuite with ScalaFutures with TestSuiteMixin with MongoDateTimeFormats with BeforeAndAfterEach with MockitoSugar {
 
   private val instant                   = Instant.now
   implicit private val stubClock: Clock = Clock.fixed(instant, ZoneId.systemDefault)
@@ -134,6 +145,87 @@ class ArrivalMovementRepositorySpec extends ItSpecBase with MongoSuite with Scal
           )
         }
       }
+    }
+
+    "started -- testing change in TTL" - {
+
+      val indexUnderTest = "last-updated-index";
+
+      class Harness(
+        cn: String,
+        mongo: ReactiveMongoApi,
+        appConfig: AppConfig,
+        config: Configuration,
+        clock: Clock,
+        override val metrics: Metrics
+      )(implicit ec: ExecutionContext, m: Materializer)
+       extends ArrivalMovementRepository(mongo, appConfig, config, clock, metrics)(ec, m) {
+         override lazy val collectionName: String = cn
+      }
+
+      def createHarness(app: Application, name: String) =
+        new Harness(
+          name,
+          app.injector.instanceOf[ReactiveMongoApi],
+          app.injector.instanceOf[AppConfig],
+          app.injector.instanceOf[Configuration],
+          app.injector.instanceOf[Clock],
+          app.injector.instanceOf[Metrics],
+        )(app.materializer.executionContext, app.materializer)
+
+      def runTest(name: String, ttl1: Int, ttl2: Int): Future[List[Index]] = {
+        def callHarness(ttl: Int): (Application, Harness) = {
+          // For this, we'll stick with what app config gives us.
+          val app = appBuilder
+            .configure(Configuration("mongodb.timeToLiveInSeconds" -> ttl))
+            // avoids starting the "real" repository, as index changes occur in the initialiser.
+            .overrides(bind[ArrivalMovementRepository].to(mock[ArrivalMovementRepository])) 
+            .build()
+
+          (app, createHarness(app, name))
+        }
+
+        // Create the index
+        Await.ready(callHarness(ttl1)._2.started, 10.seconds)
+       
+        // We now run the harness again to reapply the drop logic
+        val (app, sut) = callHarness(ttl2)
+        val mongo = app.injector.instanceOf[ReactiveMongoApi]
+
+        sut
+          .started
+          .flatMap(_ => mongo.database)
+          .flatMap(_.collection[JSONCollection](name).indexesManager.list)
+      }
+
+      "must persist the same TTL if required" in {
+        // For this, we'll stick with what app config gives us.
+        whenReady(runTest("ttl-same", 200, 200)) {
+          indexes =>
+            val filtered: Option[Index] = indexes.filter(_.name.contains(indexUnderTest)).headOption
+            filtered match {
+              case Some(x) =>
+                x.expireAfterSeconds.get mustBe 200
+              case None =>
+                fail(s"Index $indexUnderTest does not exist or does not have a TTL")
+            }
+        }
+      }
+
+      "must use the new TTL if required" in {
+        // For this, we'll stick with what app config gives us.
+        whenReady(runTest("ttl-different", 200, 300)) {
+          indexes =>
+            val filtered: Option[Index] = indexes.filter(_.name.contains(indexUnderTest)).headOption
+            filtered match {
+              case Some(x) =>
+                x.expireAfterSeconds.get mustBe 300
+              case None =>
+                fail(s"Index $indexUnderTest does not exist or does not have a TTL")
+            }
+        }
+      }
+
     }
 
     "insert" - {


### PR DESCRIPTION
I've looked at adding a test for this, but due to IntelliJ not being able to cope with reactive mongo, and reactive mongo's judicious use of structural typing, writing tests for this might be a little convoluted. 

I have tested this locally, when the index TTL is wrong it does get dropped and recreated. When it's correct, I get the log message telling me otherwise.

I'm going to see if I can figure out a reasonable way to test this in isolation but it may not be that easy to do as we'll need to make sure we test all scenarios, and with the way the class is set up, that's not easy to do.